### PR TITLE
Standardize API Responses Across All Controllers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,12 @@
 import sentry_sdk
-from fastapi import FastAPI
+
+from fastapi import FastAPI, HTTPException
 from fastapi.routing import APIRoute
 from starlette.middleware.cors import CORSMiddleware
 
 from app.api.main import api_router
+from app.api.deps import http_exception_handler
 from app.core.config import settings
-
 
 def custom_generate_unique_id(route: APIRoute) -> str:
     return f"{route.tags[0]}-{route.name}"
@@ -31,3 +32,5 @@ if settings.all_cors_origins:
     )
 
 app.include_router(api_router, prefix=settings.API_V1_STR)
+
+app.add_exception_handler(HTTPException, http_exception_handler)

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Generic, Optional, TypeVar
 
 import emails  # type: ignore
 import jwt
@@ -12,8 +12,26 @@ from jwt.exceptions import InvalidTokenError
 from app.core import security
 from app.core.config import settings
 
+from typing import Generic, Optional, TypeVar
+from pydantic import BaseModel
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+class APIResponse(BaseModel, Generic[T]):
+    success: bool
+    data: Optional[T] = None
+    error: Optional[str] = None
+
+    @classmethod
+    def success_response(cls, data: T) -> "APIResponse[T]":
+        return cls(success=True, data=data, error=None)
+
+    @classmethod
+    def failure_response(cls, error: str) -> "APIResponse[None]":
+        return cls(success=False, data=None, error=error)
 
 
 @dataclass


### PR DESCRIPTION
Target issue : #66 

This PR introduces a standardized API response format across all controllers using the APIResponse model. 

### Example For success response:

```
@router.post("/{user_id}", response_model=APIResponse[ProjectUserPublic])
def add_user(...):
    if not user:
        raise HTTPException(status_code=404, detail="User not found")

    try:
        new_project_user = add_user_to_project(session, project_id, user_id, is_admin)
        return APIResponse.success_response(new_project_user)
    except ValueError as e:
        raise HTTPException(status_code=400, detail=str(e))
```
###  How HTTP Exceptions Are Handled

With the introduction of a global exception handler, all HTTPException responses will be formatted uniformly.

What This Means:

- Developers can continue using raise HTTPException(status_code, "error message")
- The response format will always follow the standard structure
- Temporary "detail" field is retained for backward compatibility