### PR TITLE
Correct SQLModel import in Alembic

### DIFF
--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -2,7 +2,7 @@ import os
 from logging.config import fileConfig
 
 from alembic import context
-from app.models import SQLModel
+from sqlmodel import SQLModel
 from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,3 @@
-from sqlmodel import SQLModel
-
 from .auth import Token, TokenPayload
 from .item import Item, ItemCreate, ItemPublic, ItemsPublic, ItemUpdate
 from .message import Message


### PR DESCRIPTION
## Summary

Target issue is #99  

This issue had already been fixed in #18 That PR somehow got lost. This is bringing it back

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

N/A


---

This pull request addresses an issue with the SQLModel import in the Alembic environment configuration. The change involves updating the import statement in `backend/app/alembic/env.py` to import SQLModel directly from the `sqlmodel` package instead of from `app.models`. This modification aims to enhance maintainability and minimize potential import-related problems.