### PR TITLE
Swagger UI: Simplify #31

### DIFF
--- a/backend/app/api/routes/credentials.py
+++ b/backend/app/api/routes/credentials.py
@@ -43,7 +43,6 @@ def create_new_credential(*, session: SessionDep, creds_in: CredsCreate):
     "/{org_id}",
     dependencies=[Depends(get_current_active_superuser)],
     response_model=APIResponse[CredsPublic],
-    include_in_schema=False,
 )
 def read_credential(*, session: SessionDep, org_id: int):
     try:

--- a/backend/app/api/routes/credentials.py
+++ b/backend/app/api/routes/credentials.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/credentials", tags=["credentials"])
 @router.post(
     "/",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[CredsPublic],
+    response_model=APIResponse[CredsPublic],include_in_schema=False
 )
 def create_new_credential(*, session: SessionDep, creds_in: CredsCreate):
     new_creds = None
@@ -41,7 +41,7 @@ def create_new_credential(*, session: SessionDep, creds_in: CredsCreate):
 @router.get(
     "/{org_id}",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[CredsPublic],
+    response_model=APIResponse[CredsPublic],include_in_schema=False
 )
 def read_credential(*, session: SessionDep, org_id: int):
     try:
@@ -60,7 +60,7 @@ def read_credential(*, session: SessionDep, org_id: int):
 @router.get(
     "/{org_id}/api-key",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[dict],
+    response_model=APIResponse[dict],include_in_schema=False
 )
 def read_api_key(*, session: SessionDep, org_id: int):
     try:

--- a/backend/app/api/routes/credentials.py
+++ b/backend/app/api/routes/credentials.py
@@ -17,7 +17,8 @@ router = APIRouter(prefix="/credentials", tags=["credentials"])
 @router.post(
     "/",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[CredsPublic],include_in_schema=False
+    response_model=APIResponse[CredsPublic],
+    include_in_schema=False,
 )
 def create_new_credential(*, session: SessionDep, creds_in: CredsCreate):
     new_creds = None
@@ -41,7 +42,8 @@ def create_new_credential(*, session: SessionDep, creds_in: CredsCreate):
 @router.get(
     "/{org_id}",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[CredsPublic],include_in_schema=False
+    response_model=APIResponse[CredsPublic],
+    include_in_schema=False,
 )
 def read_credential(*, session: SessionDep, org_id: int):
     try:
@@ -60,7 +62,8 @@ def read_credential(*, session: SessionDep, org_id: int):
 @router.get(
     "/{org_id}/api-key",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[dict],include_in_schema=False
+    response_model=APIResponse[dict],
+    include_in_schema=False,
 )
 def read_api_key(*, session: SessionDep, org_id: int):
     try:

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -25,7 +25,7 @@ def raise_from_unknown(error: Exception):
     raise HTTPException(status_code=500, detail=str(error))
 
 
-@router.get("/ls", response_model=APIResponse[List[Document]],include_in_schema=False)
+@router.get("/ls", response_model=APIResponse[List[Document]], include_in_schema=False)
 def list_docs(
     session: SessionDep,
     current_user: CurrentUser,
@@ -43,7 +43,7 @@ def list_docs(
     return APIResponse.success_response(data)
 
 
-@router.post("/cp", response_model=APIResponse[Document],include_in_schema=False)
+@router.post("/cp", response_model=APIResponse[Document], include_in_schema=False)
 def upload_doc(
     session: SessionDep,
     current_user: CurrentUser,
@@ -73,7 +73,9 @@ def upload_doc(
     return APIResponse.success_response(data)
 
 
-@router.get("/rm/{doc_id}", response_model=APIResponse[Document],include_in_schema=False)
+@router.get(
+    "/rm/{doc_id}", response_model=APIResponse[Document], include_in_schema=False
+)
 def delete_doc(
     session: SessionDep,
     current_user: CurrentUser,

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -43,7 +43,7 @@ def list_docs(
     return APIResponse.success_response(data)
 
 
-@router.post("/cp", response_model=APIResponse[Document], include_in_schema=False)
+@router.post("/cp", response_model=APIResponse[Document])
 def upload_doc(
     session: SessionDep,
     current_user: CurrentUser,

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -25,7 +25,7 @@ def raise_from_unknown(error: Exception):
     raise HTTPException(status_code=500, detail=str(error))
 
 
-@router.get("/ls", response_model=APIResponse[List[Document]])
+@router.get("/ls", response_model=APIResponse[List[Document]],include_in_schema=False)
 def list_docs(
     session: SessionDep,
     current_user: CurrentUser,
@@ -43,7 +43,7 @@ def list_docs(
     return APIResponse.success_response(data)
 
 
-@router.post("/cp", response_model=APIResponse[Document])
+@router.post("/cp", response_model=APIResponse[Document],include_in_schema=False)
 def upload_doc(
     session: SessionDep,
     current_user: CurrentUser,
@@ -73,7 +73,7 @@ def upload_doc(
     return APIResponse.success_response(data)
 
 
-@router.get("/rm/{doc_id}", response_model=APIResponse[Document])
+@router.get("/rm/{doc_id}", response_model=APIResponse[Document],include_in_schema=False)
 def delete_doc(
     session: SessionDep,
     current_user: CurrentUser,

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -50,7 +50,7 @@ def login_access_token(
     )
 
 
-@router.post("/login/test-token", response_model=UserPublic)
+@router.post("/login/test-token", response_model=UserPublic,include_in_schema=False)
 def test_token(current_user: CurrentUser) -> Any:
     """
     Test access token
@@ -58,7 +58,7 @@ def test_token(current_user: CurrentUser) -> Any:
     return current_user
 
 
-@router.post("/password-recovery/{email}")
+@router.post("/password-recovery/{email}",include_in_schema=False)
 def recover_password(email: str, session: SessionDep) -> Message:
     """
     Password Recovery
@@ -82,7 +82,7 @@ def recover_password(email: str, session: SessionDep) -> Message:
     return Message(message="Password recovery email sent")
 
 
-@router.post("/reset-password/")
+@router.post("/reset-password/",include_in_schema=False)
 def reset_password(session: SessionDep, body: NewPassword) -> Message:
     """
     Reset password
@@ -108,7 +108,7 @@ def reset_password(session: SessionDep, body: NewPassword) -> Message:
 @router.post(
     "/password-recovery-html-content/{email}",
     dependencies=[Depends(get_current_active_superuser)],
-    response_class=HTMLResponse,
+    response_class=HTMLResponse,include_in_schema=False
 )
 def recover_password_html_content(email: str, session: SessionDep) -> Any:
     """

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -50,7 +50,7 @@ def login_access_token(
     )
 
 
-@router.post("/login/test-token", response_model=UserPublic,include_in_schema=False)
+@router.post("/login/test-token", response_model=UserPublic, include_in_schema=False)
 def test_token(current_user: CurrentUser) -> Any:
     """
     Test access token
@@ -58,7 +58,7 @@ def test_token(current_user: CurrentUser) -> Any:
     return current_user
 
 
-@router.post("/password-recovery/{email}",include_in_schema=False)
+@router.post("/password-recovery/{email}", include_in_schema=False)
 def recover_password(email: str, session: SessionDep) -> Message:
     """
     Password Recovery
@@ -82,7 +82,7 @@ def recover_password(email: str, session: SessionDep) -> Message:
     return Message(message="Password recovery email sent")
 
 
-@router.post("/reset-password/",include_in_schema=False)
+@router.post("/reset-password/", include_in_schema=False)
 def reset_password(session: SessionDep, body: NewPassword) -> Message:
     """
     Reset password
@@ -108,7 +108,8 @@ def reset_password(session: SessionDep, body: NewPassword) -> Message:
 @router.post(
     "/password-recovery-html-content/{email}",
     dependencies=[Depends(get_current_active_superuser)],
-    response_class=HTMLResponse,include_in_schema=False
+    response_class=HTMLResponse,
+    include_in_schema=False,
 )
 def recover_password_html_content(email: str, session: SessionDep) -> Any:
     """

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -90,7 +90,8 @@ def update_organization(
 @router.delete(
     "/{org_id}",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[None],include_in_schema=False
+    response_model=APIResponse[None],
+    include_in_schema=False,
 )
 def delete_organization(session: SessionDep, org_id: int):
     org = get_organization_by_id(session=session, org_id=org_id)

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -90,7 +90,7 @@ def update_organization(
 @router.delete(
     "/{org_id}",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[None],
+    response_model=APIResponse[None],include_in_schema=False
 )
 def delete_organization(session: SessionDep, org_id: int):
     org = get_organization_by_id(session=session, org_id=org_id)

--- a/backend/app/api/routes/private.py
+++ b/backend/app/api/routes/private.py
@@ -20,7 +20,7 @@ class PrivateUserCreate(BaseModel):
     is_verified: bool = False
 
 
-@router.post("/users/", response_model=UserPublic)
+@router.post("/users/", response_model=UserPublic,include_in_schema=False)
 def create_user(user_in: PrivateUserCreate, session: SessionDep) -> Any:
     """
     Create a new user.

--- a/backend/app/api/routes/private.py
+++ b/backend/app/api/routes/private.py
@@ -20,7 +20,7 @@ class PrivateUserCreate(BaseModel):
     is_verified: bool = False
 
 
-@router.post("/users/", response_model=UserPublic,include_in_schema=False)
+@router.post("/users/", response_model=UserPublic, include_in_schema=False)
 def create_user(user_in: PrivateUserCreate, session: SessionDep) -> Any:
     """
     Create a new user.

--- a/backend/app/api/routes/project.py
+++ b/backend/app/api/routes/project.py
@@ -87,7 +87,11 @@ def update_project(*, session: SessionDep, project_id: int, project_in: ProjectU
 
 
 # Delete a project
-@router.delete("/{project_id}", dependencies=[Depends(get_current_active_superuser)],include_in_schema=False)
+@router.delete(
+    "/{project_id}",
+    dependencies=[Depends(get_current_active_superuser)],
+    include_in_schema=False,
+)
 def delete_project(session: SessionDep, project_id: int):
     project = get_project_by_id(session=session, project_id=project_id)
     if project is None:

--- a/backend/app/api/routes/project.py
+++ b/backend/app/api/routes/project.py
@@ -87,7 +87,7 @@ def update_project(*, session: SessionDep, project_id: int, project_in: ProjectU
 
 
 # Delete a project
-@router.delete("/{project_id}", dependencies=[Depends(get_current_active_superuser)])
+@router.delete("/{project_id}", dependencies=[Depends(get_current_active_superuser)],include_in_schema=False)
 def delete_project(session: SessionDep, project_id: int):
     project = get_project_by_id(session=session, project_id=project_id)
     if project is None:

--- a/backend/app/api/routes/project_user.py
+++ b/backend/app/api/routes/project_user.py
@@ -17,7 +17,9 @@ router = APIRouter(prefix="/project/users", tags=["project_users"])
 
 
 # Add a user to a project
-@router.post("/{user_id}", response_model=APIResponse[ProjectUserPublic],include_in_schema=False)
+@router.post(
+    "/{user_id}", response_model=APIResponse[ProjectUserPublic], include_in_schema=False
+)
 def add_user(
     request: Request,
     user_id: uuid.UUID,
@@ -52,7 +54,9 @@ def add_user(
 
 
 # Get all users in a project
-@router.get("/", response_model=APIResponse[list[ProjectUserPublic]],include_in_schema=False)
+@router.get(
+    "/", response_model=APIResponse[list[ProjectUserPublic]], include_in_schema=False
+)
 def list_project_users(
     session: Session = Depends(get_db),
     current_user: UserProjectOrg = Depends(verify_user_project_organization),
@@ -72,7 +76,9 @@ def list_project_users(
 
 
 # Remove a user from a project
-@router.delete("/{user_id}", response_model=APIResponse[Message],include_in_schema=False)
+@router.delete(
+    "/{user_id}", response_model=APIResponse[Message], include_in_schema=False
+)
 def remove_user(
     request: Request,
     user_id: uuid.UUID,

--- a/backend/app/api/routes/project_user.py
+++ b/backend/app/api/routes/project_user.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/project/users", tags=["project_users"])
 
 
 # Add a user to a project
-@router.post("/{user_id}", response_model=APIResponse[ProjectUserPublic])
+@router.post("/{user_id}", response_model=APIResponse[ProjectUserPublic],include_in_schema=False)
 def add_user(
     request: Request,
     user_id: uuid.UUID,
@@ -52,7 +52,7 @@ def add_user(
 
 
 # Get all users in a project
-@router.get("/", response_model=APIResponse[list[ProjectUserPublic]])
+@router.get("/", response_model=APIResponse[list[ProjectUserPublic]],include_in_schema=False)
 def list_project_users(
     session: Session = Depends(get_db),
     current_user: UserProjectOrg = Depends(verify_user_project_organization),
@@ -72,7 +72,7 @@ def list_project_users(
 
 
 # Remove a user from a project
-@router.delete("/{user_id}", response_model=APIResponse[Message])
+@router.delete("/{user_id}", response_model=APIResponse[Message],include_in_schema=False)
 def remove_user(
     request: Request,
     user_id: uuid.UUID,

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -31,7 +31,8 @@ router = APIRouter(prefix="/users", tags=["users"])
 @router.get(
     "/",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=UsersPublic,include_in_schema=False
+    response_model=UsersPublic,
+    include_in_schema=False,
 )
 def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
     """
@@ -48,7 +49,10 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 
 
 @router.post(
-    "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic,include_in_schema=False
+    "/",
+    dependencies=[Depends(get_current_active_superuser)],
+    response_model=UserPublic,
+    include_in_schema=False,
 )
 def create_user_endpoint(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
@@ -154,7 +158,7 @@ def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     return user
 
 
-@router.get("/{user_id}", response_model=UserPublic,include_in_schema=False)
+@router.get("/{user_id}", response_model=UserPublic, include_in_schema=False)
 def read_user_by_id(
     user_id: uuid.UUID, session: SessionDep, current_user: CurrentUser
 ) -> Any:
@@ -175,7 +179,8 @@ def read_user_by_id(
 @router.patch(
     "/{user_id}",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=UserPublic,include_in_schema=False
+    response_model=UserPublic,
+    include_in_schema=False,
 )
 def update_user_endpoint(
     *,
@@ -204,7 +209,11 @@ def update_user_endpoint(
     return db_user
 
 
-@router.delete("/{user_id}", dependencies=[Depends(get_current_active_superuser)],include_in_schema=False)
+@router.delete(
+    "/{user_id}",
+    dependencies=[Depends(get_current_active_superuser)],
+    include_in_schema=False,
+)
 def delete_user(
     session: SessionDep, current_user: CurrentUser, user_id: uuid.UUID
 ) -> Message:

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -31,7 +31,7 @@ router = APIRouter(prefix="/users", tags=["users"])
 @router.get(
     "/",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=UsersPublic,
+    response_model=UsersPublic,include_in_schema=False
 )
 def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
     """
@@ -48,7 +48,7 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 
 
 @router.post(
-    "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
+    "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic,include_in_schema=False
 )
 def create_user_endpoint(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
@@ -154,7 +154,7 @@ def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     return user
 
 
-@router.get("/{user_id}", response_model=UserPublic)
+@router.get("/{user_id}", response_model=UserPublic,include_in_schema=False)
 def read_user_by_id(
     user_id: uuid.UUID, session: SessionDep, current_user: CurrentUser
 ) -> Any:
@@ -175,7 +175,7 @@ def read_user_by_id(
 @router.patch(
     "/{user_id}",
     dependencies=[Depends(get_current_active_superuser)],
-    response_model=UserPublic,
+    response_model=UserPublic,include_in_schema=False
 )
 def update_user_endpoint(
     *,
@@ -204,7 +204,7 @@ def update_user_endpoint(
     return db_user
 
 
-@router.delete("/{user_id}", dependencies=[Depends(get_current_active_superuser)])
+@router.delete("/{user_id}", dependencies=[Depends(get_current_active_superuser)],include_in_schema=False)
 def delete_user(
     session: SessionDep, current_user: CurrentUser, user_id: uuid.UUID
 ) -> Message:

--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -11,7 +11,8 @@ router = APIRouter(prefix="/utils", tags=["utils"])
 @router.post(
     "/test-email/",
     dependencies=[Depends(get_current_active_superuser)],
-    status_code=201,include_in_schema=False
+    status_code=201,
+    include_in_schema=False,
 )
 def test_email(email_to: EmailStr) -> Message:
     """
@@ -26,6 +27,6 @@ def test_email(email_to: EmailStr) -> Message:
     return Message(message="Test email sent")
 
 
-@router.get("/health/",include_in_schema=False)
+@router.get("/health/", include_in_schema=False)
 async def health_check() -> bool:
     return True

--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/utils", tags=["utils"])
 @router.post(
     "/test-email/",
     dependencies=[Depends(get_current_active_superuser)],
-    status_code=201,
+    status_code=201,include_in_schema=False
 )
 def test_email(email_to: EmailStr) -> Message:
     """
@@ -26,6 +26,6 @@ def test_email(email_to: EmailStr) -> Message:
     return Message(message="Test email sent")
 
 
-@router.get("/health/")
+@router.get("/health/",include_in_schema=False)
 async def health_check() -> bool:
     return True


### PR DESCRIPTION
## Summary
Target issue is #31

**Context:**
The Swagger UI (/docs) was showing a long list of internal or unused endpoints that are not relevant for production usage or external consumers.

**What’s Done:**

- Applied include_in_schema=False to internal or deprecated routes to hide them from Swagger documentation.
- This keeps the API docs clean and focused only on relevant public endpoints.

**Like shown in image** 
<img width="505" alt="Screenshot 2025-05-05 at 12 28 55 PM" src="https://github.com/user-attachments/assets/e40a53df-8c8d-4bae-8e73-ca436b8b2002" />



- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.
