### PR TITLE
Rename document endpoints to be more descriptive

### DIFF
--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -17,7 +17,7 @@ from app.crud.rag import OpenAIAssistantCrud
 router = APIRouter(prefix="/documents", tags=["documents"])
 
 
-@router.get("/ls", response_model=APIResponse[List[Document]])
+@router.get("/list", response_model=APIResponse[List[Document]])
 def list_docs(
     session: SessionDep,
     current_user: CurrentUser,
@@ -35,7 +35,7 @@ def list_docs(
     return APIResponse.success_response(data)
 
 
-@router.post("/cp", response_model=APIResponse[Document])
+@router.post("/upload", response_model=APIResponse[Document])
 def upload_doc(
     session: SessionDep,
     current_user: CurrentUser,
@@ -68,10 +68,10 @@ def upload_doc(
 
 
 @router.get(
-    "/rm/{doc_id}",
+    "/remove/{doc_id}",
     response_model=APIResponse[Document],
 )
-def delete_doc(
+def remove_doc(
     session: SessionDep,
     current_user: CurrentUser,
     doc_id: UUID,
@@ -91,7 +91,7 @@ def delete_doc(
     return APIResponse.success_response(data)
 
 
-@router.get("/stat/{doc_id}", response_model=APIResponse[Document])
+@router.get("/info/{doc_id}", response_model=APIResponse[Document])
 def doc_info(
     session: SessionDep,
     current_user: CurrentUser,

--- a/backend/app/tests/api/routes/documents/test_route_document_info.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_info.py
@@ -14,10 +14,10 @@ from app.tests.utils.document import (
 
 @pytest.fixture
 def route():
-    return Route("stat")
+    return Route("info")
 
 
-class TestDocumentRouteStat:
+class TestDocumentRouteInfo:
     def test_response_is_success(
         self,
         db: Session,
@@ -29,7 +29,7 @@ class TestDocumentRouteStat:
 
         assert response.is_success
 
-    def test_stat_reflects_database(
+    def test_info_reflects_database(
         self,
         db: Session,
         route: Route,
@@ -43,7 +43,7 @@ class TestDocumentRouteStat:
 
         assert source == target.data
 
-    def test_cannot_stat_unknown_document(
+    def test_cannot_info_unknown_document(
         self,
         db: Session,
         route: Route,

--- a/backend/app/tests/api/routes/documents/test_route_document_list.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_list.py
@@ -21,7 +21,7 @@ class QueryRoute(Route):
 
 @pytest.fixture
 def route():
-    return QueryRoute("ls")
+    return QueryRoute("list")
 
 
 class TestDocumentRouteList:

--- a/backend/app/tests/api/routes/documents/test_route_document_remove.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_remove.py
@@ -1,4 +1,5 @@
 import pytest
+import openai_responses
 from sqlmodel import Session, select
 
 from app.models import Document
@@ -9,6 +10,8 @@ from app.tests.utils.document import (
     WebCrawler,
     crawler,
 )
+from app.tests.utils.collection import get_collection
+from app.tests.utils.utils import openai_credentials
 
 
 @pytest.fixture
@@ -16,7 +19,9 @@ def route():
     return Route("remove")
 
 
+@pytest.mark.usefixtures("openai_credentials")
 class TestDocumentRouteRemove:
+    @openai_responses.mock()
     def test_response_is_success(
         self,
         db: Session,
@@ -28,6 +33,7 @@ class TestDocumentRouteRemove:
 
         assert response.is_success
 
+    @openai_responses.mock()
     def test_item_is_soft_removed(
         self,
         db: Session,
@@ -44,6 +50,7 @@ class TestDocumentRouteRemove:
 
         assert result.removed_at is not None
 
+    @openai_responses.mock()
     def test_cannot_remove_unknown_document(
         self,
         db: Session,

--- a/backend/app/tests/api/routes/documents/test_route_document_remove.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_remove.py
@@ -13,10 +13,10 @@ from app.tests.utils.document import (
 
 @pytest.fixture
 def route():
-    return Route("rm")
+    return Route("remove")
 
 
-class TestDocumentRouteDelete:
+class TestDocumentRouteRemove:
     def test_response_is_success(
         self,
         db: Session,
@@ -28,7 +28,7 @@ class TestDocumentRouteDelete:
 
         assert response.is_success
 
-    def test_item_is_soft_deleted(
+    def test_item_is_soft_removed(
         self,
         db: Session,
         route: Route,
@@ -42,9 +42,9 @@ class TestDocumentRouteDelete:
         statement = select(Document).where(Document.id == document.id)
         result = db.exec(statement).one()
 
-        assert result.deleted_at is not None
+        assert result.removed_at is not None
 
-    def test_cannot_delete_unknown_document(
+    def test_cannot_remove_unknown_document(
         self,
         db: Session,
         route: Route,

--- a/backend/app/tests/api/routes/documents/test_route_document_remove.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_remove.py
@@ -48,7 +48,7 @@ class TestDocumentRouteRemove:
         statement = select(Document).where(Document.id == document.id)
         result = db.exec(statement).one()
 
-        assert result.removed_at is not None
+        assert result.deleted_at is not None
 
     @openai_responses.mock()
     def test_cannot_remove_unknown_document(

--- a/backend/app/tests/api/routes/documents/test_route_document_upload.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_upload.py
@@ -41,7 +41,7 @@ def scratch():
 
 @pytest.fixture
 def route():
-    return Route("cp")
+    return Route("upload")
 
 
 @pytest.fixture

--- a/backend/app/tests/crud/collections/test_crud_collection_create.py
+++ b/backend/app/tests/crud/collections/test_crud_collection_create.py
@@ -5,7 +5,8 @@ from sqlmodel import Session, select
 from app.crud import CollectionCrud
 from app.models import DocumentCollection
 from app.tests.utils.document import DocumentStore
-from app.tests.utils.collection import get_collection, openai_credentials
+from app.tests.utils.collection import get_collection
+from app.tests.utils.utils import openai_credentials
 
 
 @pytest.mark.usefixtures("openai_credentials")

--- a/backend/app/tests/crud/collections/test_crud_collection_delete.py
+++ b/backend/app/tests/crud/collections/test_crud_collection_delete.py
@@ -7,11 +7,8 @@ from app.core.config import settings
 from app.crud import CollectionCrud
 from app.crud.rag import OpenAIAssistantCrud
 from app.tests.utils.document import DocumentStore
-from app.tests.utils.collection import (
-    get_collection,
-    openai_credentials,
-    uuid_increment,
-)
+from app.tests.utils.collection import get_collection, uuid_increment
+from app.tests.utils.utils import openai_credentials
 
 
 @pytest.mark.usefixtures("openai_credentials")

--- a/backend/app/tests/crud/collections/test_crud_collection_read_all.py
+++ b/backend/app/tests/crud/collections/test_crud_collection_read_all.py
@@ -7,7 +7,8 @@ from app.crud import CollectionCrud
 from app.core.config import settings
 from app.models import Collection
 from app.tests.utils.document import DocumentStore
-from app.tests.utils.collection import get_collection, openai_credentials
+from app.tests.utils.collection import get_collection
+from app.tests.utils.utils import openai_credentials
 
 
 def create_collections(db: Session, n: int):

--- a/backend/app/tests/crud/collections/test_crud_collection_read_one.py
+++ b/backend/app/tests/crud/collections/test_crud_collection_read_one.py
@@ -7,11 +7,8 @@ from sqlalchemy.exc import NoResultFound
 from app.core.config import settings
 from app.crud import CollectionCrud
 from app.tests.utils.document import DocumentStore
-from app.tests.utils.collection import (
-    get_collection,
-    openai_credentials,
-    uuid_increment,
-)
+from app.tests.utils.collection import get_collection, uuid_increment
+from app.tests.utils.utils import openai_credentials
 
 
 def mk_collection(db: Session):

--- a/backend/app/tests/utils/collection.py
+++ b/backend/app/tests/utils/collection.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-import pytest
 from openai import OpenAI
 from sqlmodel import Session
 
@@ -11,7 +10,6 @@ from app.tests.utils.utils import get_user_id_by_email
 
 class constants:
     openai_model = "gpt-4o"
-    openai_mock_key = "sk-fake123"
     llm_service_name = "test-service-name"
 
 
@@ -47,8 +45,3 @@ def get_collection(db: Session, client=None):
         llm_service_id=assistant.id,
         llm_service_name=constants.llm_service_name,
     )
-
-
-@pytest.fixture(scope="class")
-def openai_credentials():
-    settings.OPENAI_API_KEY = constants.openai_mock_key

--- a/backend/app/tests/utils/utils.py
+++ b/backend/app/tests/utils/utils.py
@@ -2,11 +2,17 @@ import random
 import string
 from uuid import UUID
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from app.core.config import settings
 from app.crud.user import get_user_by_email
+
+
+@pytest.fixture(scope="class")
+def openai_credentials():
+    settings.OPENAI_API_KEY = "sk-fake123"
 
 
 def random_lower_string() -> str:


### PR DESCRIPTION
## Summary

Target issue is #175 

Existing document routes names are only meaningful to those with UNIX experience. This update makes them more meaningful to a wider audience

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

N/A
