### PR TITLE
Credentials : Use this functionality in threads endpoint #169

### DIFF
--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -29,3 +29,12 @@ from .api_key import (
     get_api_keys_by_organization,
     delete_api_key,
 )
+
+from .credentials import (
+    set_creds_for_org,
+    get_creds_by_org,
+    get_key_by_org,  # Ensure this is included
+    update_creds_for_org,
+    remove_creds_for_org,
+    remove_provider_credential,
+)

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -36,5 +36,4 @@ from .credentials import (
     get_key_by_org,  # Ensure this is included
     update_creds_for_org,
     remove_creds_for_org,
-    remove_provider_credential,
 )

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -33,7 +33,7 @@ from .api_key import (
 from .credentials import (
     set_creds_for_org,
     get_creds_by_org,
-    get_key_by_org,  # Ensure this is included
+    get_key_by_org,
     update_creds_for_org,
     remove_creds_for_org,
 )


### PR DESCRIPTION
This PR introduces organization-level API key management by dynamically retrieving the OpenAI API key from the database (credentials table) based on the currently authenticated user's organization. It replaces the use of the global settings.OPENAI_API_KEY, enabling secure and scalable multi-tenant support.

**Benefits**

- Multi-tenancy Ready: Each organization can now use its own OpenAI key, improving data isolation and tenant-specific billing or rate limits.
- Security: Eliminates reliance on a single shared API key, reducing the impact of key leakage or misuse.
- Flexibility: Supports seamless onboarding of new organizations with custom OpenAI keys without redeploying the service.
- Extensibility: The foundation is laid to support multiple providers (e.g., Gemini, Claude) with minimal changes via the existing credential structure.


- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.
