### PR TITLE
dalgo migration :  Incorrect Request Type in start_thread Endpoint

### DIFF
--- a/backend/app/api/routes/threads.py
+++ b/backend/app/api/routes/threads.py
@@ -333,7 +333,7 @@ async def threads_sync(
 
 @router.post("/threads/start")
 async def start_thread(
-    request: OpenAIThreadCreate,
+    request: dict,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     _current_user: UserOrganization = Depends(get_current_user_org),


### PR DESCRIPTION
## Summary

This PR fixes an issue where the request parameter in the start_thread endpoint was incorrectly typed as OpenAIThreadCreate. The request should not be of type OpenAIThreadCreate, but rather a general dict type, as it only represents the data sent in the body of the request and not the entity being saved to the database
