### PR TITLE
[ BUG] Gracefully handle empty callback URL

### DIFF
--- a/backend/app/api/routes/collections.py
+++ b/backend/app/api/routes/collections.py
@@ -228,7 +228,11 @@ def do_delete_collection(
     request: DeletionRequest,
     payload: ResponsePayload,
 ):
-    callback = CallbackHandler(request.callback_url, payload)
+    if request.callback_url is None:
+        callback = SilentCallback(payload)
+    else:
+        callback = WebHookCallback(request.callback_url, payload)
+
     collection_crud = CollectionCrud(session, current_user.id)
     try:
         collection = collection_crud.read_one(request.collection_id)


### PR DESCRIPTION
## Summary

Target issue is #190 

Collection deletion will fail if no callback URL is provided.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

N/A
