### PR TITLE
Enhance error handling for OpenAI client and Langfuse configuration

### DIFF
--- a/backend/app/api/routes/threads.py
+++ b/backend/app/api/routes/threads.py
@@ -232,7 +232,12 @@ async def threads(
         return APIResponse.failure_response(
             error="OpenAI API key not configured for this organization."
         )
-    client = OpenAI(api_key=credentials["api_key"])
+
+    try:
+        client = OpenAI(api_key=credentials["api_key"])
+    except Exception as e:
+        logger.error(f"Failed to initialize OpenAI client: {e}")
+        return APIResponse.failure_response(error="Failed to initialize OpenAI client.")
 
     langfuse_credentials = get_provider_credential(
         session=_session,
@@ -244,12 +249,17 @@ async def threads(
         return APIResponse.failure_response(
             error="LANGFUSE keys not configured for this organization."
         )
-
-    langfuse_context.configure(
-        secret_key=langfuse_credentials["secret_key"],
-        public_key=langfuse_credentials["public_key"],
-        host=langfuse_credentials["host"],
-    )
+    try:
+        langfuse_context.configure(
+            secret_key=langfuse_credentials["secret_key"],
+            public_key=langfuse_credentials["public_key"],
+            host=langfuse_credentials["host"],
+        )
+    except Exception as e:
+        logger.error(f"Failed to configure Langfuse: {e}")
+        return APIResponse.failure_response(
+            error="Failed to configure Langfuse tracing."
+        )
     # Validate thread
     is_valid, error_message = validate_thread(client, request.get("thread_id"))
     if not is_valid:
@@ -295,7 +305,11 @@ async def threads_sync(
             error="OpenAI API key not configured for this organization."
         )
 
-    client = OpenAI(api_key=credentials["api_key"])
+    try:
+        client = OpenAI(api_key=credentials["api_key"])
+    except Exception as e:
+        logger.error(f"Failed to initialize OpenAI client: {e}")
+        return APIResponse.failure_response(error="Failed to initialize OpenAI client.")
 
     # Validate thread
     is_valid, error_message = validate_thread(client, request.get("thread_id"))


### PR DESCRIPTION
## Summary

This Pr improves the /threads endpoint by adding separate and robust error handling for OpenAI and Langfuse credential retrieval and initialization. It ensures that if either OpenAI or Langfuse setup fails, the endpoint returns clear and meaningful error responses instead of breaking abruptly. This makes the API more resilient and user-friendly.
- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

