### PR TITLE
Seed Data: Fix hardcoded IDs and DB issue

### DIFF
--- a/backend/app/seed_data/seed_data.json
+++ b/backend/app/seed_data/seed_data.json
@@ -40,14 +40,14 @@
   "apikeys": [
     {
       "organization_name": "Project Tech4dev",
-      "user_id": "4629f304-10c5-45f8-80f5-26ea1066a1cb",
+      "user_email": "superuser@example.com",
       "api_key": "ApiKey No3x47A5qoIGhm0kVKjQ77dhCqEdWRIQZlEPzzzh7i8",
       "is_deleted": false,
       "deleted_at": null
     },
     {
       "organization_name": "Project Tech4dev",
-      "user_id": "375503ac-f9d1-465e-8a87-be6974799ce1",
+      "user_email": "org_admin@example.com",
       "api_key": "ApiKey Px8y47B6roJHin1lWLkR88eiDrFdXSJRZmFQazzai8j9",
       "is_deleted": false,
       "deleted_at": null

--- a/backend/app/seed_data/seed_data.json
+++ b/backend/app/seed_data/seed_data.json
@@ -1,61 +1,56 @@
 {
-    "organization": [
-      {
-        "id": 1,
-        "name": "Project Tech4dev",
-        "is_active": true
-      }
-    ],
-    "projects": [
-      {
-        "id": 1,
-        "name": "Glific",
-        "description": "Two way communication platform",
-        "is_active": true,
-        "organization_id": 1
-      },
-      {
-        "id": 2,
-        "name": "Dalgo",
-        "description": "Data platform for the social sector",
-        "is_active": true,
-        "organization_id": 1
-      }
-    ],
-    "users": [
-      {
-        "id": "4629f304-10c5-45f8-80f5-26ea1066a1cb",
-        "email": "superuser@example.com",
-        "password": "changethis",
-        "full_name": "SUPERUSER",
-        "is_active": true,
-        "is_superuser": true
-      },
-      {
-        "id": "375503ac-f9d1-465e-8a87-be6974799ce1",
-        "email": "org_admin@example.com",
-        "password": "admin123",
-        "full_name": "ADMIN",
-        "is_active": true,
-        "is_superuser": false
-      }
-    ],
-    "apikeys": [
-      {
-        "id": 1,
-        "organization_id": 1,
-        "user_id": "4629f304-10c5-45f8-80f5-26ea1066a1cb",
-        "api_key": "ApiKey No3x47A5qoIGhm0kVKjQ77dhCqEdWRIQZlEPzzzh7i8",
-        "is_deleted": false,
-        "deleted_at": null
-      },
-      {
-        "id": 2,
-        "organization_id": 1,
-        "user_id": "375503ac-f9d1-465e-8a87-be6974799ce1",
-        "api_key": "ApiKey Px8y47B6roJHin1lWLkR88eiDrFdXSJRZmFQazzai8j9",
-        "is_deleted": false,
-        "deleted_at": null
-      }
-    ]
-  }
+  "organization": [
+    {
+      "name": "Project Tech4dev",
+      "is_active": true
+    }
+  ],
+  "projects": [
+    {
+      "name": "Glific",
+      "description": "Two way communication platform",
+      "is_active": true,
+      "organization_name": "Project Tech4dev"
+    },
+    {
+      "name": "Dalgo",
+      "description": "Data platform for the social sector",
+      "is_active": true,
+      "organization_name": "Project Tech4dev"
+    }
+  ],
+  "users": [
+    {
+      "id": "4629f304-10c5-45f8-80f5-26ea1066a1cb",
+      "email": "superuser@example.com",
+      "password": "changethis",
+      "full_name": "SUPERUSER",
+      "is_active": true,
+      "is_superuser": true
+    },
+    {
+      "id": "375503ac-f9d1-465e-8a87-be6974799ce1",
+      "email": "org_admin@example.com",
+      "password": "admin123",
+      "full_name": "ADMIN",
+      "is_active": true,
+      "is_superuser": false
+    }
+  ],
+  "apikeys": [
+    {
+      "organization_name": "Project Tech4dev",
+      "user_id": "4629f304-10c5-45f8-80f5-26ea1066a1cb",
+      "api_key": "ApiKey No3x47A5qoIGhm0kVKjQ77dhCqEdWRIQZlEPzzzh7i8",
+      "is_deleted": false,
+      "deleted_at": null
+    },
+    {
+      "organization_name": "Project Tech4dev",
+      "user_id": "375503ac-f9d1-465e-8a87-be6974799ce1",
+      "api_key": "ApiKey Px8y47B6roJHin1lWLkR88eiDrFdXSJRZmFQazzai8j9",
+      "is_deleted": false,
+      "deleted_at": null
+    }
+  ]
+}

--- a/backend/app/seed_data/seed_data.json
+++ b/backend/app/seed_data/seed_data.json
@@ -21,7 +21,6 @@
   ],
   "users": [
     {
-      "id": "4629f304-10c5-45f8-80f5-26ea1066a1cb",
       "email": "superuser@example.com",
       "password": "changethis",
       "full_name": "SUPERUSER",
@@ -29,7 +28,6 @@
       "is_superuser": true
     },
     {
-      "id": "375503ac-f9d1-465e-8a87-be6974799ce1",
       "email": "org_admin@example.com",
       "password": "admin123",
       "full_name": "ADMIN",

--- a/backend/app/seed_data/seed_data.py
+++ b/backend/app/seed_data/seed_data.py
@@ -1,14 +1,15 @@
-import uuid
 import json
-from pathlib import Path
-from sqlmodel import Session, delete, select
-from app.models import Organization, Project, User, APIKey
-from app.core.security import get_password_hash, encrypt_api_key
-from app.core.db import engine
 import logging
 from datetime import datetime
-from pydantic import BaseModel, EmailStr
+from pathlib import Path
 from typing import Optional
+
+from pydantic import BaseModel, EmailStr
+from sqlmodel import Session, delete, select
+
+from app.core.db import engine
+from app.core.security import encrypt_api_key, get_password_hash
+from app.models import APIKey, Organization, Project, User
 
 
 # Pydantic models for data validation

--- a/backend/app/seed_data/seed_data.py
+++ b/backend/app/seed_data/seed_data.py
@@ -25,7 +25,6 @@ class ProjectData(BaseModel):
 
 
 class UserData(BaseModel):
-    id: str
     email: EmailStr
     full_name: str
     is_superuser: bool
@@ -106,7 +105,6 @@ def create_user(session: Session, user_data_raw: dict) -> User:
         logging.info(f"Creating user: {user_data.email}")
         hashed_password = get_password_hash(user_data.password)
         user = User(
-            id=uuid.UUID(user_data.id),
             email=user_data.email,
             full_name=user_data.full_name,
             is_superuser=user_data.is_superuser,


### PR DESCRIPTION
## Summary
This PR modifies the seed.py script to eliminate manual ID assignments for organization, projects, and apikeys tables, using natural keys (organization.name) to establish relationships. This prevents primary key conflicts during subsequent API insertions by allowing PostgreSQL to auto-assign IDs using its sequences.

Target issue is #207 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

The original seed.py script manually assigned id fields (e.g., Project(id=1)) to ensure consistent relationships in seeded data. However, this caused PostgreSQL sequences (e.g., project_id_seq) to remain out of sync, leading to primary key conflicts when new records were inserted via the API (e.g., attempting to reuse id=1). This PR resolves the issue by:

1. Removing explicit id assignments in the seed data for organization, projects, and apikeys.
2. Using organization_name as a natural key to query organization.id for relationships in projects and apikeys.
3. Allowing PostgreSQL to manage ID generation, ensuring subsequent API insertions use the next available IDs without conflicts.
4. This approach ensures the seed script is robust, avoids manual ID management, and prevents conflicts in all tables with sequence-based IDs

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.
