### PR TITLE
Implement Permanent File Deletion for Document Endpoints

### DIFF
--- a/backend/app/api/docs/documents/permanent_delete.md
+++ b/backend/app/api/docs/documents/permanent_delete.md
@@ -1,2 +1,5 @@
-Permanently deletes a document from the database and its associated file from cloud storage. This action is irreversible.
-If the document is part of collections, those collections will be deleted, including any associated OpenAI Vector Stores and Assistants.
+This operation performs a soft delete on the document — the document remains in the database but is marked as deleted. However, the associated file in cloud storage is permanently deleted. This file deletion is irreversible.
+If the document is part of an active collection, those collections
+will be deleted using the collections delete interface. Noteably, this
+means all OpenAI Vector Store's and Assistant's to which this document
+belongs will be deleted.

--- a/backend/app/api/docs/documents/permanent_delete.md
+++ b/backend/app/api/docs/documents/permanent_delete.md
@@ -1,4 +1,4 @@
-This operation performs a soft delete on the document — the document remains in the database but is marked as deleted. However, the associated file in cloud storage is permanently deleted. This file deletion is irreversible.
+This operation soft deletes the document — meaning its metadata and reference are retained in the database, but it is marked as deleted. The actual file stored in cloud storage (e.g., S3) is permanently deleted, and this action is irreversible.
 If the document is part of an active collection, those collections
 will be deleted using the collections delete interface. Noteably, this
 means all OpenAI Vector Store's and Assistant's to which this document

--- a/backend/app/api/docs/documents/permanent_delete.md
+++ b/backend/app/api/docs/documents/permanent_delete.md
@@ -1,0 +1,2 @@
+Permanently deletes a document from the database and its associated file from cloud storage. This action is irreversible.
+If the document is part of collections, those collections will be deleted, including any associated OpenAI Vector Stores and Assistants.

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -75,7 +75,7 @@ def remove_doc(
 
 
 @router.delete(
-    "remove/{doc_id}/permanent",
+    "/remove/{doc_id}/permanent",
     description=load_description("documents/permanent_delete.md"),
     response_model=APIResponse[Document],
 )

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -74,6 +74,30 @@ def remove_doc(
     return APIResponse.success_response(data)
 
 
+@router.delete(
+    "remove/{doc_id}/permanent",
+    description=load_description("documents/permanent_delete.md"),
+    response_model=APIResponse[Document],
+)
+def permanent_delete_doc(
+    session: SessionDep,
+    current_user: CurrentUser,
+    doc_id: UUID = FastPath(description="Document to permanently delete"),
+):
+    a_crud = OpenAIAssistantCrud()
+    d_crud = DocumentCrud(session, current_user.id)
+    c_crud = CollectionCrud(session, current_user.id)
+    storage = AmazonCloudStorage(current_user)
+
+    document = d_crud.read_one(doc_id)
+
+    c_crud.delete(document, a_crud)
+    storage.delete(document.object_store_url)
+    d_crud.hard_delete(doc_id)
+
+    return APIResponse.success_response(document)
+
+
 @router.get(
     "/info/{doc_id}",
     description=load_description("documents/info.md"),

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -93,7 +93,7 @@ def permanent_delete_doc(
 
     c_crud.delete(document, a_crud)
     storage.delete(document.object_store_url)
-    d_crud.hard_delete(doc_id)
+    d_crud.delete(doc_id)
 
     return APIResponse.success_response(document)
 

--- a/backend/app/core/cloud/storage.py
+++ b/backend/app/core/cloud/storage.py
@@ -124,3 +124,11 @@ class AmazonCloudStorage(CloudStorage):
             return self.aws.client.get_object(**kwargs).get("Body")
         except ClientError as err:
             raise CloudStorageError(f'AWS Error: "{err}" ({url})') from err
+
+    def delete(self, url: str) -> None:
+        name = SimpleStorageName.from_url(url)
+        kwargs = asdict(name)
+        try:
+            self.aws.client.delete_object(**kwargs)
+        except ClientError as err:
+            raise CloudStorageError(f'AWS Error: "{err}" ({url})') from err

--- a/backend/app/crud/document.py
+++ b/backend/app/crud/document.py
@@ -88,3 +88,9 @@ class DocumentCrud:
         document.updated_at = now()
 
         return self.update(document)
+
+    def hard_delete(self, doc_id: UUID) -> Document:
+        document = self.read_one(doc_id)
+        self.session.delete(document)
+        self.session.commit()
+        return document

--- a/backend/app/crud/document.py
+++ b/backend/app/crud/document.py
@@ -88,9 +88,3 @@ class DocumentCrud:
         document.updated_at = now()
 
         return self.update(document)
-
-    def hard_delete(self, doc_id: UUID) -> Document:
-        document = self.read_one(doc_id)
-        self.session.delete(document)
-        self.session.commit()
-        return document

--- a/backend/app/tests/api/routes/documents/test_route_document_permanent_remove.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_permanent_remove.py
@@ -1,0 +1,79 @@
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+from moto import mock_aws
+from sqlmodel import Session, select
+
+import openai_responses
+
+from app.core.cloud import AmazonCloudStorageClient
+from app.core.config import settings
+from app.models import Document
+from app.tests.utils.document import (
+    DocumentStore,
+    DocumentMaker,
+    Route,
+    WebCrawler,
+)
+
+
+@pytest.fixture
+def route():
+    return Route("remove")
+
+@pytest.fixture(scope="class")
+def aws_credentials():
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = settings.AWS_DEFAULT_REGION
+
+
+@pytest.mark.usefixtures("openai_credentials", "aws_credentials")
+@mock_aws
+class TestDocumentRoutePermanentRemove:
+
+    @openai_responses.mock()
+    def test_permanently_deletes_document_from_db_and_s3(
+        self,
+        db: Session,
+        route: Route,
+        crawler: WebCrawler,
+    ):
+        # Setup AWS
+        aws = AmazonCloudStorageClient()
+        aws.create()
+
+        # Setup document in DB and S3
+        store = DocumentStore(db)
+        document = store.put()
+        s3_key = Path(urlparse(document.object_store_url).path).relative_to("/")
+        aws.client.put_object(Bucket=settings.AWS_S3_BUCKET, Key=str(s3_key), Body=b"test")
+
+        # Delete document
+        response = crawler.delete(route.append(document, suffix="permanent"))
+        assert response.is_success
+
+        db.refresh(document)
+
+        stmt = select(Document).where(Document.id == document.id)
+        doc_in_db = db.exec(stmt).first()
+        assert doc_in_db is not None
+        assert doc_in_db.deleted_at is not None
+
+    @openai_responses.mock()
+    def test_cannot_delete_nonexistent_document(
+        self,
+        db: Session,
+        route: Route,
+        crawler: WebCrawler,
+    ):
+        DocumentStore.clear(db)
+
+        maker = DocumentMaker(db)
+        response = crawler.delete(route.append(next(maker), suffix="permanent"))
+
+        assert response.is_error

--- a/backend/app/tests/api/routes/documents/test_route_document_permanent_remove.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_permanent_remove.py
@@ -23,6 +23,7 @@ from app.tests.utils.document import (
 def route():
     return Route("remove")
 
+
 @pytest.fixture(scope="class")
 def aws_credentials():
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
@@ -35,7 +36,6 @@ def aws_credentials():
 @pytest.mark.usefixtures("openai_credentials", "aws_credentials")
 @mock_aws
 class TestDocumentRoutePermanentRemove:
-
     @openai_responses.mock()
     def test_permanently_deletes_document_from_db_and_s3(
         self,
@@ -51,7 +51,9 @@ class TestDocumentRoutePermanentRemove:
         store = DocumentStore(db)
         document = store.put()
         s3_key = Path(urlparse(document.object_store_url).path).relative_to("/")
-        aws.client.put_object(Bucket=settings.AWS_S3_BUCKET, Key=str(s3_key), Body=b"test")
+        aws.client.put_object(
+            Bucket=settings.AWS_S3_BUCKET, Key=str(s3_key), Body=b"test"
+        )
 
         # Delete document
         response = crawler.delete(route.append(document, suffix="permanent"))

--- a/backend/app/tests/api/routes/documents/test_route_document_permanent_remove.py
+++ b/backend/app/tests/api/routes/documents/test_route_document_permanent_remove.py
@@ -40,7 +40,7 @@ def aws_credentials():
 @mock_aws
 class TestDocumentRoutePermanentRemove:
     @openai_responses.mock()
-    def test_permanently_deletes_document_from_db_and_s3(
+    def test_permanent_delete_document_from_s3(
         self,
         db: Session,
         route: Route,

--- a/backend/app/tests/utils/document.py
+++ b/backend/app/tests/utils/document.py
@@ -37,7 +37,7 @@ class DocumentMaker:
 
     def __next__(self):
         doc_id = next(self.index)
-        key = f"{self.owner_id}/{doc_id}.xyz"
+        key = f"{self.owner_id}/{doc_id}.txt"
         object_store_url = f"s3://{settings.AWS_S3_BUCKET}/{key}"
 
         return Document(


### PR DESCRIPTION
## Summary

Target issue #220 
Explain the **motivation** for making this change. What existing problem does the pull request solve?

Addition of new Endpoint(remove/{doc_id}/permanent)  which will:

soft deletes the document — meaning its metadata and reference are retained in the database, but it is marked as deleted (deleted_at is set). The actual file stored in cloud storage (e.g., S3) is permanently deleted, and this action is irreversible.
If the document is part of an active collection, those collections
will be deleted using the collections delete interface. Noteably, this
means all OpenAI Vector Store's and Assistant's to which this document
belongs will be deleted.


## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

