### PR TITLE
Add StartThreadRequest Pydantic schema for thread/start endpoint

### DIFF
--- a/backend/app/api/routes/threads.py
+++ b/backend/app/api/routes/threads.py
@@ -28,7 +28,8 @@ class StartThreadRequest(BaseModel):
         default=False, description="Whether to remove citations from the response."
     )
     thread_id: Optional[str] = Field(
-        default=None, description="An optional existing thread ID to continue the conversation."
+        default=None,
+        description="An optional existing thread ID to continue the conversation.",
     )
 
 

--- a/backend/app/api/routes/threads.py
+++ b/backend/app/api/routes/threads.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from openai import OpenAI
 from pydantic import BaseModel, Field
 from sqlmodel import Session
+from typing import Optional
 from langfuse.decorators import observe, langfuse_context
 
 from app.api.deps import get_current_user_org, get_db
@@ -25,6 +26,9 @@ class StartThreadRequest(BaseModel):
     assistant_id: str = Field(..., description="The ID of the assistant to be used.")
     remove_citation: bool = Field(
         default=False, description="Whether to remove citations from the response."
+    )
+    thread_id: Optional[str] = Field(
+        default=None, description="An optional existing thread ID to continue the conversation."
     )
 
 

--- a/backend/app/api/routes/threads.py
+++ b/backend/app/api/routes/threads.py
@@ -4,6 +4,7 @@ import requests
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from openai import OpenAI
+from pydantic import BaseModel, Field
 from sqlmodel import Session
 from langfuse.decorators import observe, langfuse_context
 
@@ -17,6 +18,14 @@ from app.core.util import configure_langfuse, configure_openai
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["threads"])
+
+
+class StartThreadRequest(BaseModel):
+    question: str = Field(..., description="The user's input question.")
+    assistant_id: str = Field(..., description="The ID of the assistant to be used.")
+    remove_citation: bool = Field(
+        default=False, description="Whether to remove citations from the response."
+    )
 
 
 def send_callback(callback_url: str, data: dict):
@@ -340,7 +349,7 @@ async def threads_sync(
 
 @router.post("/threads/start")
 async def start_thread(
-    request: dict,
+    request: StartThreadRequest,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     _current_user: UserOrganization = Depends(get_current_user_org),
@@ -348,6 +357,7 @@ async def start_thread(
     """
     Create a new OpenAI thread for the given question and start polling in the background.
     """
+    request = request.model_dump()
     prompt = request["question"]
     credentials = get_provider_credential(
         session=db,


### PR DESCRIPTION
## Summary

Target issue #216 

This PR introduces a new Pydantic schema, StartThreadRequest, used to validate and structure incoming request data for the /thread/start endpoint.

Changes:
Added StartThreadRequest schema with the following fields:

- question (str): the user's query
- assistant_id (str): the OpenAI assistant ID
- remove_citation (bool): flag to control citation behavior (default False)

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

