### PR TITLE
Auth: Implementation of org access control 

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -147,6 +147,24 @@ def get_current_active_superuser_org(current_user: CurrentUserOrg) -> User:
     return current_user
 
 
+def has_org_access(_current_user: CurrentUserOrg, org_id: int):
+    if _current_user.is_superuser:
+        return
+    if _current_user.organization_id != org_id:
+        raise HTTPException(
+            status_code=403, detail="Access to this organization is forbidden"
+        )
+
+
+def check_org_creation_allowed(_current_user: CurrentUserOrg):
+    if _current_user.is_superuser:
+        return
+    if _current_user.organization_id is not None:
+        raise HTTPException(
+            status_code=403, detail="Not allowed to create another organization"
+        )
+
+
 def verify_user_project_organization(
     db: SessionDep,
     current_user: CurrentUserOrg,

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -104,15 +104,6 @@ def get_current_user_org(
             validate_organization(session, api_key_record.organization_id)
             organization_id = api_key_record.organization_id
 
-    if not api_key:
-        api_key_record = (
-            session.query(APIKey)
-            .filter(APIKey.user_id == current_user.id, APIKey.is_deleted.is_(False))
-            .first()
-        )
-        if api_key_record:
-            organization_id = api_key_record.organization_id
-
     return UserOrganization(
         **current_user.model_dump(), organization_id=organization_id
     )

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -93,6 +93,7 @@ CurrentUser = Annotated[User, Depends(get_current_user)]
 def get_current_user_org(
     current_user: CurrentUser, session: SessionDep, request: Request
 ) -> UserOrganization:
+    print("🔍 Current user inside dependency:", current_user)
     """Extend `User` with organization_id if available, otherwise return UserOrganization without it."""
 
     if current_user.is_superuser:

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -107,7 +107,7 @@ def get_current_user_org(
     if not api_key:
         api_key_record = (
             session.query(APIKey)
-            .filter(APIKey.user_id == current_user.id, APIKey.is_deleted.is_(True))
+            .filter(APIKey.user_id == current_user.id, APIKey.is_deleted.is_(False))
             .first()
         )
         if api_key_record:

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -93,11 +93,7 @@ CurrentUser = Annotated[User, Depends(get_current_user)]
 def get_current_user_org(
     current_user: CurrentUser, session: SessionDep, request: Request
 ) -> UserOrganization:
-    print("🔍 Current user inside dependency:", current_user)
     """Extend `User` with organization_id if available, otherwise return UserOrganization without it."""
-
-    if current_user.is_superuser:
-        return UserOrganization(**current_user.model_dump(), organization_id=None)
 
     organization_id = None
     api_key = request.headers.get("X-API-KEY")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -20,7 +20,6 @@ from app.models import (
     User,
     UserProjectOrg,
     UserOrganization,
-    UserOrganizations,
     ProjectUser,
     Project,
     Organization,

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -14,7 +14,7 @@ from app.core.config import settings
 from app.core.db import engine
 from app.utils import APIResponse
 from app.crud.organization import validate_organization
-from app.crud.api_key import get_api_key_by_value, get_api_key_by_user
+from app.crud.api_key import get_api_key_by_value
 from app.models import (
     TokenPayload,
     User,

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 from typing import Annotated, Optional
 
 import jwt
+import logging
 from fastapi import Depends, HTTPException, status, Request, Path, Query
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer, APIKeyHeader
@@ -25,7 +26,7 @@ from app.models import (
     Organization,
     APIKey,
 )
-import logging
+
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,9 @@ def get_current_user_org(
 
     if not api_key:
         api_key_record = (
-            session.query(APIKey).filter(APIKey.user_id == current_user.id).first()
+            session.query(APIKey)
+            .filter(APIKey.user_id == current_user.id, APIKey.is_deleted.is_(True))
+            .first()
         )
         if api_key_record:
             organization_id = api_key_record.organization_id

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -23,6 +23,7 @@ from app.models import (
     ProjectUser,
     Project,
     Organization,
+    APIKey,
 )
 
 reusable_oauth2 = OAuth2PasswordBearer(
@@ -97,6 +98,13 @@ def get_current_user_org(
         api_key_record = get_api_key_by_value(session, api_key)
         if api_key_record:
             validate_organization(session, api_key_record.organization_id)
+            organization_id = api_key_record.organization_id
+
+    if not api_key:
+        api_key_record = (
+            session.query(APIKey).filter(APIKey.user_id == current_user.id).first()
+        )
+        if api_key_record:
             organization_id = api_key_record.organization_id
 
     return UserOrganization(

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -155,18 +155,15 @@ def get_current_active_superuser_org(current_user: CurrentUserOrg) -> User:
     return current_user
 
 
-def has_org_access(_current_user: CurrentUserOrg, org_id: int):
+def check_org_access(_current_user: CurrentUserOrg, org_id: int = None):
     if _current_user.is_superuser:
         return
-    if _current_user.organization_id != org_id:
+
+    if org_id is not None and _current_user.organization_id != org_id:
         raise HTTPException(
             status_code=403, detail="Access to this organization is forbidden"
         )
 
-
-def check_org_creation_allowed(_current_user: CurrentUserOrg):
-    if _current_user.is_superuser:
-        return
     if _current_user.organization_id is not None:
         raise HTTPException(
             status_code=403, detail="Not allowed to create another organization"

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -32,10 +32,7 @@ router = APIRouter(prefix="/organizations", tags=["organizations"])
     response_model=APIResponse[List[OrganizationPublic]],
 )
 def read_organizations(
-    session: SessionDep,
-    skip: int = 0,
-    limit: int = 100,
-    current_user=CurrentUserOrg,
+    session: SessionDep, current_user: CurrentUserOrg, skip: int = 0, limit: int = 100
 ):
     """
     Return all organizations for superuser,
@@ -43,7 +40,7 @@ def read_organizations(
     """
 
     if current_user.is_superuser:
-        statement = select(Organization).where(Organization.is_deleted == False)
+        statement = select(Organization).where(Organization.is_active == True)
     else:
         if not current_user.organization_id:
             return APIResponse.success_response([])

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -1,8 +1,7 @@
-from typing import Any, List
+from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import func
-from sqlmodel import Session, select
+from fastapi import APIRouter
+from sqlmodel import select
 
 from app.models import (
     Organization,
@@ -11,70 +10,65 @@ from app.models import (
     OrganizationPublic,
 )
 from app.api.deps import (
-    CurrentUser,
+    CurrentUserOrg,
     SessionDep,
-    get_current_active_superuser,
+    has_org_access,
+    check_org_creation_allowed,
 )
-from app.crud.organization import create_organization, get_organization_by_id
+from app.crud.organization import create_organization, validate_organization
 from app.utils import APIResponse
+
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
 
 
 # Retrieve organizations
-@router.get(
-    "/",
-    dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[List[OrganizationPublic]],
-)
-def read_organizations(session: SessionDep, skip: int = 0, limit: int = 100):
-    count_statement = select(func.count()).select_from(Organization)
-    count = session.exec(count_statement).one()
-
-    statement = select(Organization).offset(skip).limit(limit)
+@router.get("/", response_model=APIResponse[List[OrganizationPublic]])
+def read_organizations(
+    session: SessionDep, _current_user: CurrentUserOrg, skip: int = 0, limit: int = 100
+):
+    if _current_user.is_superuser:
+        statement = select(Organization).offset(skip).limit(limit)
+    else:
+        statement = (
+            select(Organization)
+            .where(Organization.id == _current_user.organization_id)
+            .offset(skip)
+            .limit(limit)
+        )
     organizations = session.exec(statement).all()
-
     return APIResponse.success_response(organizations)
 
 
-# Create a new organization
-@router.post(
-    "/",
-    dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[OrganizationPublic],
-)
-def create_new_organization(*, session: SessionDep, org_in: OrganizationCreate):
+@router.post("/", response_model=APIResponse[OrganizationPublic])
+def create_new_organization(
+    *, session: SessionDep, _current_user: CurrentUserOrg, org_in: OrganizationCreate
+):
+    check_org_creation_allowed(_current_user)
     new_org = create_organization(session=session, org_create=org_in)
     return APIResponse.success_response(new_org)
 
 
-@router.get(
-    "/{org_id}",
-    dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[OrganizationPublic],
-)
-def read_organization(*, session: SessionDep, org_id: int):
-    """
-    Retrieve an organization by ID.
-    """
-    org = get_organization_by_id(session=session, org_id=org_id)
-    if org is None:
-        raise HTTPException(status_code=404, detail="Organization not found")
+@router.get("/{org_id}", response_model=APIResponse[OrganizationPublic])
+def read_organization(
+    *, session: SessionDep, _current_user: CurrentUserOrg, org_id: int
+):
+    org = validate_organization(session=session, org_id=org_id)
+    has_org_access(_current_user, org_id)
+
     return APIResponse.success_response(org)
 
 
-# Update an organization
-@router.patch(
-    "/{org_id}",
-    dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[OrganizationPublic],
-)
+@router.patch("/{org_id}", response_model=APIResponse[OrganizationPublic])
 def update_organization(
-    *, session: SessionDep, org_id: int, org_in: OrganizationUpdate
+    *,
+    session: SessionDep,
+    _current_user: CurrentUserOrg,
+    org_id: int,
+    org_in: OrganizationUpdate,
 ):
-    org = get_organization_by_id(session=session, org_id=org_id)
-    if org is None:
-        raise HTTPException(status_code=404, detail="Organization not found")
+    org = validate_organization(session=session, org_id=org_id)
+    has_org_access(_current_user, org_id)
 
     org_data = org_in.model_dump(exclude_unset=True)
     org = org.model_copy(update=org_data)
@@ -86,17 +80,12 @@ def update_organization(
     return APIResponse.success_response(org)
 
 
-# Delete an organization
-@router.delete(
-    "/{org_id}",
-    dependencies=[Depends(get_current_active_superuser)],
-    response_model=APIResponse[None],
-    include_in_schema=False,
-)
-def delete_organization(session: SessionDep, org_id: int):
-    org = get_organization_by_id(session=session, org_id=org_id)
-    if org is None:
-        raise HTTPException(status_code=404, detail="Organization not found")
+@router.delete("/{org_id}", response_model=APIResponse[None], include_in_schema=False)
+def delete_organization(
+    session: SessionDep, _current_user: CurrentUserOrg, org_id: int
+):
+    org = validate_organization(session=session, org_id=org_id)
+    has_org_access(_current_user, org_id)
 
     session.delete(org)
     session.commit()

--- a/backend/app/api/routes/organization.py
+++ b/backend/app/api/routes/organization.py
@@ -1,7 +1,8 @@
-from typing import List
+from typing import Any, List
 
-from fastapi import APIRouter
-from sqlmodel import select
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
+from sqlmodel import Session, select
 
 from app.models import (
     Organization,
@@ -9,64 +10,100 @@ from app.models import (
     OrganizationUpdate,
     OrganizationPublic,
 )
-from app.api.deps import CurrentUserOrg, SessionDep, check_org_access
-from app.crud.organization import create_organization, validate_organization
+from app.api.deps import (
+    CurrentUserOrg,
+    SessionDep,
+    get_current_active_superuser,
+    check_org_access,
+)
+from app.crud.organization import (
+    create_organization,
+    get_organization_by_id,
+    validate_organization,
+)
 from app.utils import APIResponse
-
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
 
 
 # Retrieve organizations
-@router.get("/", response_model=APIResponse[List[OrganizationPublic]])
+@router.get(
+    "/",
+    response_model=APIResponse[List[OrganizationPublic]],
+)
 def read_organizations(
-    session: SessionDep, _current_user: CurrentUserOrg, skip: int = 0, limit: int = 100
+    session: SessionDep,
+    skip: int = 0,
+    limit: int = 100,
+    current_user=CurrentUserOrg,
 ):
-    """Get a list of organizations for the current user."""
-    if _current_user.is_superuser:
-        statement = select(Organization).offset(skip).limit(limit)
+    """
+    Return all organizations for superuser,
+    or only the one associated with the current user.
+    """
+
+    if current_user.is_superuser:
+        statement = select(Organization).where(Organization.is_deleted == False)
     else:
-        statement = (
-            select(Organization)
-            .where(Organization.id == _current_user.organization_id)
-            .offset(skip)
-            .limit(limit)
+        if not current_user.organization_id:
+            return APIResponse.success_response([])
+
+        statement = select(Organization).where(
+            Organization.id == current_user.organization_id,
+            Organization.is_deleted == False,
         )
+
+    statement = statement.offset(skip).limit(limit)
     organizations = session.exec(statement).all()
+
     return APIResponse.success_response(organizations)
 
 
-@router.post("/", response_model=APIResponse[OrganizationPublic])
-def create_new_organization(
-    *, session: SessionDep, _current_user: CurrentUserOrg, org_in: OrganizationCreate
-):
-    """Create a new organization if allowed."""
-    check_org_access(_current_user)
+# Create a new organization
+@router.post(
+    "/",
+    dependencies=[Depends(get_current_active_superuser)],
+    response_model=APIResponse[OrganizationPublic],
+)
+def create_new_organization(*, session: SessionDep, org_in: OrganizationCreate):
+    """
+    Creates a new organization, note that only a superuser can create an organization.
+    """
     new_org = create_organization(session=session, org_create=org_in)
     return APIResponse.success_response(new_org)
 
 
-@router.get("/{org_id}", response_model=APIResponse[OrganizationPublic])
-def read_organization(
-    *, session: SessionDep, _current_user: CurrentUserOrg, org_id: int
-):
-    """Read a specific organization by ID."""
+# Retrieve an organization by ID
+@router.get(
+    "/{org_id}",
+    response_model=APIResponse[OrganizationPublic],
+)
+def read_organization(*, session: SessionDep, org_id: int, _=Depends(check_org_access)):
+    """
+    Retrieves an organization by ID,
+    a normal user can only retrieve the organization(s) associated with their user ID.
+    """
     org = validate_organization(session=session, org_id=org_id)
-    check_org_access(_current_user, org_id)  # Check access to the organization
     return APIResponse.success_response(org)
 
 
-@router.patch("/{org_id}", response_model=APIResponse[OrganizationPublic])
+# Update an organization
+@router.patch(
+    "/{org_id}",
+    response_model=APIResponse[OrganizationPublic],
+)
 def update_organization(
     *,
     session: SessionDep,
-    _current_user: CurrentUserOrg,
     org_id: int,
     org_in: OrganizationUpdate,
+    _=Depends(check_org_access),
 ):
-    """Update an existing organization."""
+    """
+    Updates an organization by ID,
+    a normal user can only update the organization(s) associated with their user ID.
+    """
     org = validate_organization(session=session, org_id=org_id)
-    check_org_access(_current_user, org_id)  # Check access to the organization
 
     org_data = org_in.model_dump(exclude_unset=True)
     org = org.model_copy(update=org_data)
@@ -78,14 +115,18 @@ def update_organization(
     return APIResponse.success_response(org)
 
 
-@router.delete("/{org_id}", response_model=APIResponse[None], include_in_schema=False)
-def delete_organization(
-    session: SessionDep, _current_user: CurrentUserOrg, org_id: int
-):
-    """Delete an organization."""
+# Delete an organization
+@router.delete(
+    "/{org_id}",
+    dependencies=[Depends(get_current_active_superuser)],
+    response_model=APIResponse[None],
+    include_in_schema=False,
+)
+def delete_organization(session: SessionDep, org_id: int):
+    """
+    Deletes an existing organization, note that only a superuser can delete an organization.
+    """
     org = validate_organization(session=session, org_id=org_id)
-    check_org_access(_current_user, org_id)  # Check access to the organization
-
     session.delete(org)
     session.commit()
 

--- a/backend/app/tests/api/routes/test_org.py
+++ b/backend/app/tests/api/routes/test_org.py
@@ -24,8 +24,21 @@ def test_organization(db: Session, superuser_token_headers: dict[str, str]):
     return organization
 
 
-# Test retrieving organizations
-def test_read_organizations(db: Session, superuser_token_headers: dict[str, str]):
+@pytest.fixture
+def other_organization(db: Session, superuser_token_headers: dict[str, str]):
+    unique_name = f"OtherOrg-{random_lower_string()}"
+    org_data = OrganizationCreate(name=unique_name, is_active=True)
+    organization = create_organization(session=db, org_create=org_data)
+    db.commit()
+    return organization
+
+
+# Test retrieving organizations (Superuser - sees all organizations)
+def test_read_organizations_as_superuser(
+    db: Session,
+    superuser_token_headers: dict[str, str],
+    test_organization: Organization,
+):
     response = client.get(
         f"{settings.API_V1_STR}/organizations/", headers=superuser_token_headers
     )
@@ -33,10 +46,15 @@ def test_read_organizations(db: Session, superuser_token_headers: dict[str, str]
     response_data = response.json()
     assert "data" in response_data
     assert isinstance(response_data["data"], list)
+    assert (
+        len(response_data["data"]) > 0
+    )  # Ensure that multiple organizations are returned
 
 
-# Test creating an organization
-def test_create_organization(db: Session, superuser_token_headers: dict[str, str]):
+# Test creating an organization (Superuser)
+def test_create_organization_as_superuser(
+    db: Session, superuser_token_headers: dict[str, str]
+):
     unique_name = f"Org-{random_lower_string()}"
     org_data = {"name": unique_name, "is_active": True}
     response = client.post(
@@ -44,23 +62,22 @@ def test_create_organization(db: Session, superuser_token_headers: dict[str, str
         json=org_data,
         headers=superuser_token_headers,
     )
-
     assert 200 <= response.status_code < 300
     created_org = response.json()
-    assert "data" in created_org  # Make sure there's a 'data' field
+    assert "data" in created_org
     created_org_data = created_org["data"]
     org = get_organization_by_id(session=db, org_id=created_org_data["id"])
-    assert org is not None  # The organization should be found in the DB
+    assert org is not None
     assert org.name == created_org_data["name"]
     assert org.is_active == created_org_data["is_active"]
 
 
-def test_update_organization(
+def test_update_organization_as_superuser(
     db: Session,
     test_organization: Organization,
     superuser_token_headers: dict[str, str],
 ):
-    unique_name = f"UpdatedOrg-{random_lower_string()}"  # Ensure a unique name
+    unique_name = f"UpdatedOrg-{random_lower_string()}"
     update_data = {"name": unique_name, "is_active": False}
 
     response = client.patch(
@@ -77,8 +94,28 @@ def test_update_organization(
     assert updated_org["is_active"] == update_data["is_active"]
 
 
-# Test deleting an organization
-def test_delete_organization(
+# Test updating an organization (Regular user - should only update their own)
+def test_update_organization_as_regular_user(
+    db: Session,
+    test_organization: Organization,
+    normal_user_token_headers: dict[str, str],
+):
+    unique_name = f"UpdatedOrg-{random_lower_string()}"
+    update_data = {"name": unique_name, "is_active": False}
+
+    # Regular user should only be allowed to update their own organization
+    response = client.patch(
+        f"{settings.API_V1_STR}/organizations/{test_organization.id}",
+        json=update_data,
+        headers=normal_user_token_headers,
+    )
+    assert (
+        response.status_code == 403
+    )  # Forbidden if trying to update someone else's organization
+
+
+# Test deleting an organization (Superuser)
+def test_delete_organization_as_superuser(
     db: Session,
     test_organization: Organization,
     superuser_token_headers: dict[str, str],
@@ -88,8 +125,38 @@ def test_delete_organization(
         headers=superuser_token_headers,
     )
     assert response.status_code == 200
+
     response = client.get(
         f"{settings.API_V1_STR}/organizations/{test_organization.id}",
         headers=superuser_token_headers,
     )
     assert response.status_code == 404
+
+
+# Test deleting an organization (Regular user - should only delete their own)
+def test_delete_organization_as_regular_user(
+    db: Session,
+    test_organization: Organization,
+    normal_user_token_headers: dict[str, str],
+):
+    response = client.delete(
+        f"{settings.API_V1_STR}/organizations/{test_organization.id}",
+        headers=normal_user_token_headers,
+    )
+    assert (
+        response.status_code == 403
+    )  # Forbidden for regular user to delete someone else's org
+
+
+# Test regular user accessing another organization (should be forbidden)
+def test_read_organization_as_regular_user_without_access(
+    db: Session,
+    normal_user_token_headers: dict[str, str],
+    other_organization: Organization,
+):
+    # Simulate a regular user with no access to another organization
+    response = client.get(
+        f"{settings.API_V1_STR}/organizations/{other_organization.id}",
+        headers=normal_user_token_headers,
+    )
+    assert response.status_code == 403  # Forbidden, as the user doesn't have access

--- a/backend/app/tests/api/routes/test_org.py
+++ b/backend/app/tests/api/routes/test_org.py
@@ -33,7 +33,6 @@ def other_organization(db: Session, superuser_token_headers: dict[str, str]):
     return organization
 
 
-# Test retrieving organizations (Superuser - sees all organizations)
 def test_read_organizations_as_superuser(
     db: Session,
     superuser_token_headers: dict[str, str],
@@ -46,12 +45,9 @@ def test_read_organizations_as_superuser(
     response_data = response.json()
     assert "data" in response_data
     assert isinstance(response_data["data"], list)
-    assert (
-        len(response_data["data"]) > 0
-    )  # Ensure that multiple organizations are returned
+    assert len(response_data["data"]) > 0
 
 
-# Test creating an organization (Superuser)
 def test_create_organization_as_superuser(
     db: Session, superuser_token_headers: dict[str, str]
 ):
@@ -94,7 +90,6 @@ def test_update_organization_as_superuser(
     assert updated_org["is_active"] == update_data["is_active"]
 
 
-# Test updating an organization (Regular user - should only update their own)
 def test_update_organization_as_regular_user(
     db: Session,
     test_organization: Organization,
@@ -103,18 +98,14 @@ def test_update_organization_as_regular_user(
     unique_name = f"UpdatedOrg-{random_lower_string()}"
     update_data = {"name": unique_name, "is_active": False}
 
-    # Regular user should only be allowed to update their own organization
     response = client.patch(
         f"{settings.API_V1_STR}/organizations/{test_organization.id}",
         json=update_data,
         headers=normal_user_token_headers,
     )
-    assert (
-        response.status_code == 403
-    )  # Forbidden if trying to update someone else's organization
+    assert response.status_code == 403
 
 
-# Test deleting an organization (Superuser)
 def test_delete_organization_as_superuser(
     db: Session,
     test_organization: Organization,
@@ -133,7 +124,6 @@ def test_delete_organization_as_superuser(
     assert response.status_code == 404
 
 
-# Test deleting an organization (Regular user - should only delete their own)
 def test_delete_organization_as_regular_user(
     db: Session,
     test_organization: Organization,
@@ -143,18 +133,14 @@ def test_delete_organization_as_regular_user(
         f"{settings.API_V1_STR}/organizations/{test_organization.id}",
         headers=normal_user_token_headers,
     )
-    assert (
-        response.status_code == 403
-    )  # Forbidden for regular user to delete someone else's org
+    assert response.status_code == 403
 
 
-# Test regular user accessing another organization (should be forbidden)
 def test_read_organization_as_regular_user_without_access(
     db: Session,
     normal_user_token_headers: dict[str, str],
     other_organization: Organization,
 ):
-    # Simulate a regular user with no access to another organization
     response = client.get(
         f"{settings.API_V1_STR}/organizations/{other_organization.id}",
         headers=normal_user_token_headers,


### PR DESCRIPTION
## Summary

Target issue is #155  and  #154 
Explain the **motivation** for making this change. What existing problem does the pull request solve?
These issues were clubbed together because the final product of both of them is to put access control on authenticated user so that they can only create or access their organization only.

## Notes

- Refactored Access and Creation Check Logic:

The check_org_access function has been introduced to streamline access control by handling both:

Access Control: Ensures that regular users can only access organizations they belong to. A 403 HTTP exception is raised if they attempt to access an unauthorized organization.

Organization Creation and deletion Permission: Only a superuser is allowed to do both of these

Note that a superuser still has access to everything.

- for Users Logged in via Username and Password:

If a user logs in using their username and password, the system will search the API key table using the user's ID to retrieve the associated organization ID. Access is only granted to the organization linked to their user ID in the API key table.

This approach is necessary because, at present, the API key table serves as the only link between users and organizations.