### PR TITLE
Auth : Only authenticated superusers allowed to register user

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -129,7 +129,6 @@ def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
 def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     """
     This endpoint allows the registration of a new user and is accessible only by a superuser.
-    To create a user with superuser privileges, set "is_superuser": true in the request payload.
     """
     if get_user_by_email(session=session, email=user_in.email):
         raise HTTPException(

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -121,8 +121,16 @@ def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
     return Message(message="User deleted successfully")
 
 
-@router.post("/signup", response_model=UserPublic)
+@router.post(
+    "/signup",
+    dependencies=[Depends(get_current_active_superuser)],
+    response_model=UserPublic,
+)
 def register_user(session: SessionDep, user_in: UserRegister) -> Any:
+    """
+    This endpoint allows the registration of a new user and is accessible only by a superuser.
+    To create a user with superuser privileges, set "is_superuser": true in the request payload.
+    """
     if get_user_by_email(session=session, email=user_in.email):
         raise HTTPException(
             status_code=400,
@@ -154,7 +162,6 @@ def read_user_by_id(
     "/{user_id}",
     dependencies=[Depends(get_current_active_superuser)],
     response_model=UserPublic,
-    include_in_schema=False,
 )
 def update_user_endpoint(
     *,

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -161,6 +161,7 @@ def read_user_by_id(
     "/{user_id}",
     dependencies=[Depends(get_current_active_superuser)],
     response_model=UserPublic,
+    include_in_schema=False,
 )
 def update_user_endpoint(
     *,

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -21,7 +21,6 @@ class UserRegister(SQLModel):
     email: EmailStr = Field(max_length=255)
     password: str = Field(min_length=8, max_length=40)
     full_name: str | None = (Field(default=None, max_length=255),)
-    is_superuser: bool = Field(default=False)
 
 
 # Properties to receive via API on update, all are optional

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -20,7 +20,7 @@ class UserCreate(UserBase):
 class UserRegister(SQLModel):
     email: EmailStr = Field(max_length=255)
     password: str = Field(min_length=8, max_length=40)
-    full_name: str | None = (Field(default=None, max_length=255),)
+    full_name: str | None = Field(default=None, max_length=255)
 
 
 # Properties to receive via API on update, all are optional

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -20,7 +20,8 @@ class UserCreate(UserBase):
 class UserRegister(SQLModel):
     email: EmailStr = Field(max_length=255)
     password: str = Field(min_length=8, max_length=40)
-    full_name: str | None = Field(default=None, max_length=255)
+    full_name: str | None = (Field(default=None, max_length=255),)
+    is_superuser: bool = Field(default=False)
 
 
 # Properties to receive via API on update, all are optional

--- a/backend/app/tests/api/routes/test_users.py
+++ b/backend/app/tests/api/routes/test_users.py
@@ -259,13 +259,16 @@ def test_update_password_me_same_password_error(
     assert updated_user["error"] == "New password cannot be the same as the current one"
 
 
-def test_register_user(client: TestClient, db: Session) -> None:
+def test_register_user(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
     username = random_email()
     password = random_lower_string()
     full_name = random_lower_string()
     data = {"email": username, "password": password, "full_name": full_name}
     r = client.post(
         f"{settings.API_V1_STR}/users/signup",
+        headers=superuser_token_headers,
         json=data,
     )
     assert r.status_code == 200
@@ -281,7 +284,9 @@ def test_register_user(client: TestClient, db: Session) -> None:
     assert verify_password(password, user_db.hashed_password)
 
 
-def test_register_user_already_exists_error(client: TestClient) -> None:
+def test_register_user_already_exists_error(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
     password = random_lower_string()
     full_name = random_lower_string()
     data = {
@@ -291,6 +296,7 @@ def test_register_user_already_exists_error(client: TestClient) -> None:
     }
     r = client.post(
         f"{settings.API_V1_STR}/users/signup",
+        headers=superuser_token_headers,
         json=data,
     )
     assert r.status_code == 400


### PR DESCRIPTION
## Summary

Target issue is #157 

## Notes
This PR introduces access control improvements for user registration and user updates:

- Restricts access to the register user endpoint by adding the get_current_active_superuser dependency.
    -> Now, only superusers can register new users.Otherwise this endpoint was completely open before as specified in issue #157 
