### PR TITLE
Testcases: Using DB Transactions

### DIFF
--- a/backend/app/tests/api/routes/collections/test_collection_info.py
+++ b/backend/app/tests/api/routes/collections/test_collection_info.py
@@ -38,7 +38,7 @@ def create_collection(
     return collection
 
 
-def test_collection_info_processing(db: Session):
+def test_collection_info_processing(db: Session, client: TestClient):
     headers = {"X-API-KEY": original_api_key}
     user = get_user_from_api_key(db, headers)
     collection = create_collection(db, user, status=CollectionStatus.processing)
@@ -57,7 +57,7 @@ def test_collection_info_processing(db: Session):
     assert data["llm_service_name"] is None
 
 
-def test_collection_info_successful(db: Session):
+def test_collection_info_successful(db: Session, client: TestClient):
     headers = {"X-API-KEY": original_api_key}
     user = get_user_from_api_key(db, headers)
     collection = create_collection(
@@ -78,7 +78,7 @@ def test_collection_info_successful(db: Session):
     assert data["llm_service_name"] == "gpt-4o"
 
 
-def test_collection_info_failed(db: Session):
+def test_collection_info_failed(db: Session, client: TestClient):
     headers = {"X-API-KEY": original_api_key}
     user = get_user_from_api_key(db, headers)
     collection = create_collection(db, user, status=CollectionStatus.failed)

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,65 +1,97 @@
-from collections.abc import Generator
-
-import pytest
+from uuid import uuid4
+from datetime import datetime, timezone
 from fastapi.testclient import TestClient
-from sqlmodel import Session, delete
-
+from sqlmodel import Session
 from app.core.config import settings
-from app.core.db import engine, init_db
+from app.models import Collection
 from app.main import app
-from app.models import (
-    APIKey,
-    Assistant,
-    Organization,
-    Project,
-    ProjectUser,
-    User,
-    OpenAI_Thread,
-    Credential,
-    Collection,
-)
-from app.tests.utils.user import authentication_token_from_email
-from app.tests.utils.utils import get_superuser_token_headers
-from app.seed_data.seed_data import seed_database
+from app.tests.utils.utils import get_user_from_api_key
+from app.models.collection import CollectionStatus
+
+client = TestClient(app)
+
+original_api_key = "ApiKey No3x47A5qoIGhm0kVKjQ77dhCqEdWRIQZlEPzzzh7i8"
 
 
-@pytest.fixture(scope="session", autouse=True)
-def db() -> Generator[Session, None, None]:
-    with Session(engine) as session:
-        init_db(session)
-        yield session
-        # Delete data in reverse dependency order
-        session.execute(delete(ProjectUser))  # Many-to-many relationship
-        session.execute(delete(Assistant))
-        session.execute(delete(Credential))
-        session.execute(delete(Project))
-        session.execute(delete(Organization))
-        session.execute(delete(APIKey))
-        session.execute(delete(User))
-        session.execute(delete(OpenAI_Thread))
-        session.execute(delete(Collection))
-        session.commit()
+def create_collection(
+    db,
+    user,
+    status: CollectionStatus = CollectionStatus.processing,
+    with_llm: bool = False,
+):
+    now = datetime.now(timezone.utc)
+    collection = Collection(
+        id=uuid4(),
+        owner_id=user.user_id,
+        organization_id=user.organization_id,
+        project_id=user.project_id,
+        status=status,
+        updated_at=now,
+    )
+    if with_llm:
+        collection.llm_service_id = f"asst_{uuid4()}"
+        collection.llm_service_name = "gpt-4o"
+
+    db.add(collection)
+    db.commit()
+    db.refresh(collection)
+    return collection
 
 
-@pytest.fixture(scope="module")
-def client() -> Generator[TestClient, None, None]:
-    with TestClient(app) as c:
-        yield c
+def test_collection_info_processing(db: Session, client: TestClient):
+    headers = {"X-API-KEY": original_api_key}
+    user = get_user_from_api_key(db, headers)
+    collection = create_collection(db, user, status=CollectionStatus.processing)
 
-
-@pytest.fixture(scope="module")
-def superuser_token_headers(client: TestClient) -> dict[str, str]:
-    return get_superuser_token_headers(client)
-
-
-@pytest.fixture(scope="module")
-def normal_user_token_headers(client: TestClient, db: Session) -> dict[str, str]:
-    return authentication_token_from_email(
-        client=client, email=settings.EMAIL_TEST_USER, db=db
+    response = client.post(
+        f"{settings.API_V1_STR}/collections/info/{collection.id}",
+        headers=headers,
     )
 
+    assert response.status_code == 200
+    data = response.json()["data"]
 
-@pytest.fixture(scope="session", autouse=True)
-def load_seed_data(db):
-    seed_database(db)
-    yield
+    assert data["id"] == str(collection.id)
+    assert data["status"] == CollectionStatus.processing.value
+    assert data["llm_service_id"] is None
+    assert data["llm_service_name"] is None
+
+
+def test_collection_info_successful(db: Session, client: TestClient):
+    headers = {"X-API-KEY": original_api_key}
+    user = get_user_from_api_key(db, headers)
+    collection = create_collection(
+        db, user, status=CollectionStatus.successful, with_llm=True
+    )
+
+    response = client.post(
+        f"{settings.API_V1_STR}/collections/info/{collection.id}",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+
+    assert data["id"] == str(collection.id)
+    assert data["status"] == CollectionStatus.successful.value
+    assert data["llm_service_id"] == collection.llm_service_id
+    assert data["llm_service_name"] == "gpt-4o"
+
+
+def test_collection_info_failed(db: Session, client: TestClient):
+    headers = {"X-API-KEY": original_api_key}
+    user = get_user_from_api_key(db, headers)
+    collection = create_collection(db, user, status=CollectionStatus.failed)
+
+    response = client.post(
+        f"{settings.API_V1_STR}/collections/info/{collection.id}",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+
+    assert data["id"] == str(collection.id)
+    assert data["status"] == CollectionStatus.failed.value
+    assert data["llm_service_id"] is None
+    assert data["llm_service_name"] is None


### PR DESCRIPTION
## Summary

Target issue is #274 
Explain the **motivation** for making this change. What existing problem does the pull request solve?
Previously, our test suite used a db fixture that maintained a single long-lived session for the entire pytest session, along with a single TestClient.
This approach caused all tests to operate on the same committed database state and share the same session throughout the test run, increasing the risk of stale session state and unintended interactions between tests.
Additionally, cleanup required explicitly deleting data at the end of the session, which was cumbersome.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Notes

- Converted the db fixture to:

   - Use scope="function" (per-test) instead of session.

   - Open a transaction for each test and roll it back after the test finishes, ensuring a base DB for every test.

    - Now when we will have this transaction setup in place, our test data won't touch our real data. Every test runs in an isolated sandbox and rolls back at the end.

- Add a savepoint (session.begin_nested()) at the start of each test to allow app code to safely call .commit() during tests without breaking the outer transaction.

    - Added an event listener to automatically re-establish a savepoint after every commit.

- Kept the seed_baseline fixture at scope="session":

   - Runs only once before the first test.

   - Seeds deterministic baseline data that all tests can rely on. to understand more, check [this](https://neon.com/blog/database-testing-with-fixtures-and-seeding#:~:text=By%20using%20static%20seeding%20for%20your%20tests%2C%20you%20ensure%20that%20they%20work%20with%20the%20same%20set%20of%20data%20every%20time%20they%20run.%20This%20makes%20your%20tests%20more%20reliable%20and%20easier%20to%20reason%20about) 

- Overrode get_db in the client fixture:

   -  Ensures that FastAPI’s get_db dependency returns the test’s transaction-bound session (db).

   - Without this, FastAPI routes would open their own sessions, which would not see uncommitted test data. To understand more about, check [here](https://www.oddbird.net/2024/02/09/testing-fastapi/#:~:text=This%20tells%20FastAPI%20to%20use%20the%20session%20object%20instead%20of%20the%20real%20get_db%20function%20when%20resolving%20the%20db%20parameter%20in%20our%20endpoint.%20Now%20all%20endpoints%20that%20use%20get_db%20will%20use%20our%20automatically%20rolled%2Dback%20session%20instead%20of%20the%20real%20database%2C%20giving%20us%20predictable%20and%20isolated%20tests.)

- Made client, superuser_token_headers, and normal_user_token_headers function-scoped to align with the per-test db.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and reliability by updating database session management for tests.
  * Changed test client and authentication fixtures to function scope for better isolation.
  * Updated test functions to use the test client fixture.
  * Introduced a new fixture to seed baseline data once per test session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->