### PR TITLE
Fix tests in `scripts/` for Python 3.12 by correcting mock assertion usage

### DIFF
--- a/backend/app/tests/scripts/test_backend_pre_start.py
+++ b/backend/app/tests/scripts/test_backend_pre_start.py
@@ -1,25 +1,18 @@
 from unittest.mock import MagicMock, patch
-
-from sqlmodel import select
-
-from app.backend_pre_start import init, logger
+from app.backend_pre_start import init
 
 
-def test_init_successful_connection() -> None:
-    engine_mock = MagicMock()
+def test_init_success():
+    mock_session = MagicMock()
+    mock_session.__enter__.return_value = mock_session
+    mock_session.exec.return_value = None
 
-    session_mock = MagicMock()
-    exec_mock = MagicMock(return_value=True)
-    session_mock.configure_mock(**{"exec.return_value": exec_mock})
-
-    with (
-        patch("sqlmodel.Session", return_value=session_mock),
-        patch.object(logger, "info"),
-        patch.object(logger, "error"),
-        patch.object(logger, "warn"),
+    fake_select = MagicMock()
+    with patch("app.backend_pre_start.Session", return_value=mock_session), patch(
+        "app.backend_pre_start.select", return_value=fake_select
     ):
         try:
-            init(engine_mock)
+            init(MagicMock())
             connection_successful = True
         except Exception:
             connection_successful = False
@@ -27,7 +20,4 @@ def test_init_successful_connection() -> None:
         assert (
             connection_successful
         ), "The database connection should be successful and not raise an exception."
-
-        assert session_mock.exec.called_once_with(
-            select(1)
-        ), "The session should execute a select statement once."
+        mock_session.exec.assert_called_once_with(fake_select)

--- a/backend/app/tests/scripts/test_test_pre_start.py
+++ b/backend/app/tests/scripts/test_test_pre_start.py
@@ -1,25 +1,18 @@
 from unittest.mock import MagicMock, patch
-
-from sqlmodel import select
-
-from app.tests_pre_start import init, logger
+from app.tests_pre_start import init
 
 
-def test_init_successful_connection() -> None:
-    engine_mock = MagicMock()
+def test_init_success():
+    mock_session = MagicMock()
+    mock_session.__enter__.return_value = mock_session
+    mock_session.exec.return_value = None
 
-    session_mock = MagicMock()
-    exec_mock = MagicMock(return_value=True)
-    session_mock.configure_mock(**{"exec.return_value": exec_mock})
-
-    with (
-        patch("sqlmodel.Session", return_value=session_mock),
-        patch.object(logger, "info"),
-        patch.object(logger, "error"),
-        patch.object(logger, "warn"),
+    fake_select = MagicMock()
+    with patch("app.tests_pre_start.Session", return_value=mock_session), patch(
+        "app.tests_pre_start.select", return_value=fake_select
     ):
         try:
-            init(engine_mock)
+            init(MagicMock())
             connection_successful = True
         except Exception:
             connection_successful = False
@@ -27,7 +20,4 @@ def test_init_successful_connection() -> None:
         assert (
             connection_successful
         ), "The database connection should be successful and not raise an exception."
-
-        assert session_mock.exec.called_once_with(
-            select(1)
-        ), "The session should execute a select statement once."
+        mock_session.exec.assert_called_once_with(fake_select)


### PR DESCRIPTION
## Summary
This PR fixes a compatibility issue with Python 3.12 that caused all tests in the `scripts/` directory to fail due to incorrect usage of `called_once_with` on a mock object.

Target issue is #228 

In Python 3.11 and earlier, using `called_once_with` as an attribute on a mock did not raise an error. However, Python 3.12 enforces stricter checks, and using `called_once_with` directly now results in:

- Replaced incorrect `called_once_with` usage with the correct `assert_called_once_with(...)` assertion.
- Properly mocked the `Session` context manager and `select` call inside the `init()` function.
- Ensured the test simulates a successful DB connection scenario.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified and consolidated tests for backend and test initialization processes, replacing previous tests with streamlined versions that focus on successful connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->