### PR TITLE
Hotfix: OpenAI Migration

### DIFF
--- a/backend/app/alembic/versions/e8ee93526b37_add_is_deleted_column_in_assistant_table.py
+++ b/backend/app/alembic/versions/e8ee93526b37_add_is_deleted_column_in_assistant_table.py
@@ -18,7 +18,8 @@ depends_on = None
 
 def upgrade():
     op.add_column(
-        "openai_assistant", sa.Column("is_deleted", sa.Boolean(), nullable=False)
+        "openai_assistant",
+        sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default="false"),
     )
     op.add_column(
         "openai_assistant", sa.Column("deleted_at", sa.DateTime(), nullable=True)


### PR DESCRIPTION
## Summary
Added fix for migration where in `openai_assistant` we add a non-nullable column without default value

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration to set a default value of "false" for the "is_deleted" field in the assistant records. This ensures new assistants are not marked as deleted by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->