### PR TITLE
Classification : train and test data to s3

### DIFF
--- a/backend/app/alembic/versions/72896bcc94da_add_data_to_s3_url_columns.py
+++ b/backend/app/alembic/versions/72896bcc94da_add_data_to_s3_url_columns.py
@@ -1,0 +1,64 @@
+"""add data to s3 url columns
+
+Revision ID: 72896bcc94da
+Revises: e317d05f49e4
+Create Date: 2025-08-22 00:44:45.426211
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision = "72896bcc94da"
+down_revision = "e317d05f49e4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("fine_tuning", "testing_file_id")
+    op.add_column(
+        "fine_tuning",
+        sa.Column("train_data_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    )
+    op.add_column(
+        "fine_tuning",
+        sa.Column("test_data_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    )
+    op.add_column(
+        "model_evaluation",
+        sa.Column(
+            "test_data_url",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            server_default="",
+        ),
+    )
+    op.add_column(
+        "model_evaluation",
+        sa.Column(
+            "prediction_data_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True
+        ),
+    )
+    op.alter_column(
+        "model_evaluation", "testing_file_id", existing_type=sa.VARCHAR(), nullable=True
+    )
+
+
+def downgrade():
+    op.drop_column("fine_tuning", "test_data_url")
+    op.drop_column("fine_tuning", "train_data_url")
+    op.add_column(
+        "fine_tuning",
+        sa.Column("testing_file_id", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+    op.drop_column("model_evaluation", "prediction_data_url")
+    op.drop_column("model_evaluation", "test_data_url")
+    op.alter_column(
+        "model_evaluation",
+        "testing_file_id",
+        existing_type=sa.VARCHAR(),
+        nullable=False,
+    )

--- a/backend/app/alembic/versions/72896bcc94da_add_data_to_s3_url_columns.py
+++ b/backend/app/alembic/versions/72896bcc94da_add_data_to_s3_url_columns.py
@@ -21,17 +21,21 @@ def upgrade():
     op.drop_column("fine_tuning", "testing_file_id")
     op.add_column(
         "fine_tuning",
-        sa.Column("train_data_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column(
+            "train_data_s3_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True
+        ),
     )
     op.add_column(
         "fine_tuning",
-        sa.Column("test_data_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column(
+            "test_data_s3_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True
+        ),
     )
 
 
 def downgrade():
-    op.drop_column("fine_tuning", "test_data_url")
-    op.drop_column("fine_tuning", "train_data_url")
+    op.drop_column("fine_tuning", "test_data_s3_url")
+    op.drop_column("fine_tuning", "train_data_s3_url")
     op.add_column(
         "fine_tuning",
         sa.Column("testing_file_id", sa.VARCHAR(), autoincrement=False, nullable=True),

--- a/backend/app/alembic/versions/72896bcc94da_add_data_to_s3_url_columns.py
+++ b/backend/app/alembic/versions/72896bcc94da_add_data_to_s3_url_columns.py
@@ -27,24 +27,6 @@ def upgrade():
         "fine_tuning",
         sa.Column("test_data_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     )
-    op.add_column(
-        "model_evaluation",
-        sa.Column(
-            "test_data_url",
-            sqlmodel.sql.sqltypes.AutoString(),
-            nullable=False,
-            server_default="",
-        ),
-    )
-    op.add_column(
-        "model_evaluation",
-        sa.Column(
-            "prediction_data_url", sqlmodel.sql.sqltypes.AutoString(), nullable=True
-        ),
-    )
-    op.alter_column(
-        "model_evaluation", "testing_file_id", existing_type=sa.VARCHAR(), nullable=True
-    )
 
 
 def downgrade():
@@ -53,12 +35,4 @@ def downgrade():
     op.add_column(
         "fine_tuning",
         sa.Column("testing_file_id", sa.VARCHAR(), autoincrement=False, nullable=True),
-    )
-    op.drop_column("model_evaluation", "prediction_data_url")
-    op.drop_column("model_evaluation", "test_data_url")
-    op.alter_column(
-        "model_evaluation",
-        "testing_file_id",
-        existing_type=sa.VARCHAR(),
-        nullable=False,
     )

--- a/backend/app/api/routes/fine_tuning.py
+++ b/backend/app/api/routes/fine_tuning.py
@@ -138,8 +138,8 @@ def process_fine_tuning_job(
                 job=fine_tune,
                 update=FineTuningUpdate(
                     training_file_id=training_file_id,
-                    train_data_url=train_data_s3_url,
-                    test_data_url=test_data_s3_url,
+                    train_data_s3_url=train_data_s3_url,
+                    test_data_s3_url=test_data_s3_url,
                     split_ratio=ratio,
                     provider_job_id=job.id,
                     status=FineTuningStatus.running,

--- a/backend/app/core/finetune/preprocessing.py
+++ b/backend/app/core/finetune/preprocessing.py
@@ -129,11 +129,15 @@ class DataPreprocessor:
         train_dict = train_data.to_dict(orient="records")
         train_jsonl = self._modify_data_format(train_dict)
 
-        uuids = uuid.uuid4().hex
-        pct = int(self.split_ratio * 100)  # percentage of data
-        train_csv_name = f"train_split_{pct}_{uuids}.csv"
-        test_csv_name = f"test_split_{pct}_{uuids}.csv"
-        train_jsonl_name = f"train_data_{pct}_{uuids}.jsonl"
+        unique_id = uuid.uuid4().hex
+        train_percentage = int(self.split_ratio * 100)  # train %
+        test_percentage = (
+            100 - train_percentage
+        )  # remaining % for test (since we used 1 - ratio earlier for test size)
+
+        train_csv_name = f"train_split_{train_percentage}_{unique_id}.csv"
+        test_csv_name = f"test_split_{test_percentage}_{unique_id}.csv"
+        train_jsonl_name = f"train_data_{train_percentage}_{unique_id}.jsonl"
 
         train_csv_url = self.upload_csv_to_s3(train_data, train_csv_name)
         test_csv_url = self.upload_csv_to_s3(test_data, test_csv_name)
@@ -141,7 +145,7 @@ class DataPreprocessor:
         train_jsonl_path = self._save_to_jsonl(train_jsonl, train_jsonl_name)
 
         return {
-            "train_csv_url": train_csv_url,
-            "test_csv_url": test_csv_url,
-            "train_jsonl_path": train_jsonl_path,
+            "train_csv_s3_url": train_csv_url,
+            "test_csv_s3_url": test_csv_url,
+            "train_jsonl_temp_filepath": train_jsonl_path,
         }

--- a/backend/app/core/finetune/preprocessing.py
+++ b/backend/app/core/finetune/preprocessing.py
@@ -3,6 +3,11 @@ import json
 import uuid
 import tempfile
 import logging
+import io
+
+from pathlib import Path
+from fastapi import UploadFile
+from starlette.datastructures import Headers
 import pandas as pd
 from sklearn.model_selection import train_test_split
 
@@ -21,6 +26,34 @@ class DataPreprocessor:
         self.generated_files = []
 
         self.system_message = {"role": "system", "content": system_message.strip()}
+
+    def upload_csv_to_s3(self, df, filename: str) -> str:
+        logger.info(
+            f"[upload_csv_to_s3] Preparing to upload '{filename}' to s3 | rows={len(df)}, cols={len(df.columns)}"
+        )
+
+        buf = io.BytesIO(df.to_csv(index=False).encode("utf-8"))
+        buf.seek(0)
+
+        headers = Headers({"content-type": "text/csv"})
+        upload = UploadFile(
+            filename=filename,
+            file=buf,
+            headers=headers,
+        )
+
+        try:
+            dest = self.storage.put(upload, basename=Path("datasets") / filename)
+            logger.info(
+                f"[upload_csv_to_s3] Upload successful | filename='{filename}', s3_url='{dest}'"
+            )
+            return str(dest)
+        except Exception as err:
+            logger.error(
+                f"[upload_csv_to_s3] Upload failed | filename='{filename}', error='{err}'",
+                exc_info=True,
+            )
+            raise
 
     def _save_to_jsonl(self, data, filename):
         temp_dir = tempfile.gettempdir()
@@ -65,14 +98,14 @@ class DataPreprocessor:
 
             if not self.query_col or not self.label_col:
                 logger.error(
-                    f"[DataPreprocessor] Dataset does not contai a 'label' column and one of: {possible_query_columns} "
+                    f"[DataPreprocessor] Dataset does not contain a 'label' column and one of: {possible_query_columns}"
                 )
                 raise ValueError(
                     f"CSV must contain a 'label' column and one of: {possible_query_columns}"
                 )
 
             logger.info(
-                f"[DataPreprocessor]Identified columns - query_col={self.query_col}, label_col={self.label_col}"
+                f"[DataPreprocessor] Identified columns - query_col={self.query_col}, label_col={self.label_col}"
             )
             return df
         finally:
@@ -90,21 +123,25 @@ class DataPreprocessor:
         )
 
         logger.info(
-            f"[DataPreprocessor]Data split complete: train_size={len(train_data)}, test_size={len(test_data)}"
+            f"[DataPreprocessor] Data split complete: train_size={len(train_data)}, test_size={len(test_data)}"
         )
 
         train_dict = train_data.to_dict(orient="records")
-        test_dict = test_data.to_dict(orient="records")
-
         train_jsonl = self._modify_data_format(train_dict)
-        test_jsonl = self._modify_data_format(test_dict)
 
-        train_file = (
-            f"train_data_{int(self.split_ratio * 100)}_{uuid.uuid4().hex}.jsonl"
-        )
-        test_file = f"test_data_{int(self.split_ratio * 100)}_{uuid.uuid4().hex}.jsonl"
+        uuids = uuid.uuid4().hex
+        pct = int(self.split_ratio * 100)  # percentage of data
+        train_csv_name = f"train_split_{pct}_{uuids}.csv"
+        test_csv_name = f"test_split_{pct}_{uuids}.csv"
+        train_jsonl_name = f"train_data_{pct}_{uuids}.jsonl"
 
-        train_path = self._save_to_jsonl(train_jsonl, train_file)
-        test_path = self._save_to_jsonl(test_jsonl, test_file)
+        train_csv_url = self.upload_csv_to_s3(train_data, train_csv_name)
+        test_csv_url = self.upload_csv_to_s3(test_data, test_csv_name)
 
-        return {"train_file": train_path, "test_file": test_path}
+        train_jsonl_path = self._save_to_jsonl(train_jsonl, train_jsonl_name)
+
+        return {
+            "train_csv_url": train_csv_url,
+            "test_csv_url": test_csv_url,
+            "train_jsonl_path": train_jsonl_path,
+        }

--- a/backend/app/models/fine_tuning.py
+++ b/backend/app/models/fine_tuning.py
@@ -22,7 +22,6 @@ class FineTuningJobBase(SQLModel):
     split_ratio: float = Field(nullable=False)
     document_id: UUID = Field(foreign_key="document.id", nullable=False)
     training_file_id: Optional[str] = Field(default=None)
-    testing_file_id: Optional[str] = Field(default=None)
     system_prompt: str = Field(sa_column=Column(Text, nullable=False))
 
 
@@ -65,6 +64,12 @@ class Fine_Tuning(FineTuningJobBase, table=True):
     fine_tuned_model: str | None = Field(
         default=None, description="Final fine tuned model name from OpenAI"
     )
+    train_data_url: str | None = Field(
+        default=None, description="S3 url of the training data stored ins S3"
+    )
+    test_data_url: str | None = Field(
+        default=None, description="S3 url of the testing data stored ins S3"
+    )
     error_message: str | None = Field(
         default=None, description="error message for when something failed"
     )
@@ -86,7 +91,8 @@ class Fine_Tuning(FineTuningJobBase, table=True):
 
 class FineTuningUpdate(SQLModel):
     training_file_id: Optional[str] = None
-    testing_file_id: Optional[str] = None
+    train_data_url: Optional[str] = None
+    test_data_url: Optional[str] = None
     split_ratio: Optional[float] = None
     provider_job_id: Optional[str] = None
     fine_tuned_model: Optional[str] = None
@@ -106,7 +112,8 @@ class FineTuningJobPublic(SQLModel):
     error_message: str | None = None
     fine_tuned_model: str | None = None
     training_file_id: str | None = None
-    testing_file_id: str | None = None
+    train_data_url: str | None = None
+    test_data_url: str | None = None
 
     inserted_at: datetime
     updated_at: datetime

--- a/backend/app/models/fine_tuning.py
+++ b/backend/app/models/fine_tuning.py
@@ -64,10 +64,10 @@ class Fine_Tuning(FineTuningJobBase, table=True):
     fine_tuned_model: str | None = Field(
         default=None, description="Final fine tuned model name from OpenAI"
     )
-    train_data_url: str | None = Field(
+    train_data_s3_url: str | None = Field(
         default=None, description="S3 url of the training data stored ins S3"
     )
-    test_data_url: str | None = Field(
+    test_data_s3_url: str | None = Field(
         default=None, description="S3 url of the testing data stored ins S3"
     )
     error_message: str | None = Field(
@@ -91,8 +91,8 @@ class Fine_Tuning(FineTuningJobBase, table=True):
 
 class FineTuningUpdate(SQLModel):
     training_file_id: Optional[str] = None
-    train_data_url: Optional[str] = None
-    test_data_url: Optional[str] = None
+    train_data_s3_url: Optional[str] = None
+    test_data_s3_url: Optional[str] = None
     split_ratio: Optional[float] = None
     provider_job_id: Optional[str] = None
     fine_tuned_model: Optional[str] = None
@@ -112,8 +112,8 @@ class FineTuningJobPublic(SQLModel):
     error_message: str | None = None
     fine_tuned_model: str | None = None
     training_file_id: str | None = None
-    train_data_url: str | None = None
-    test_data_url: str | None = None
+    train_data_s3_url: str | None = None
+    test_data_s3_url: str | None = None
 
     inserted_at: datetime
     updated_at: datetime


### PR DESCRIPTION
## Summary

Target issue is #341 

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.

## Changes Made

``app/core/finetune/preprocessing.py``

**S3 Upload Support**

- Added upload_csv_to_s3() method to upload train/test CSV splits directly to S3.
 
- Added detailed logging for both successful and failed uploads.

**File Naming** 

- Standardized naming for train/test splits using pct (split ratio %) and a unique uuid.

- Generates both:

   - .csv → uploaded to S3

   - .jsonl → stored locally in temp (for fine-tuning)

**Preprocessor class now returns**

   - train_csv_url → S3 path of training split CSV

   - test_csv_url → S3 path of test split CSV

   - train_jsonl_path → local path of training JSONL

``app/api/routes/fine_tuning.py``

- Removed test data upload to OpenAI

   - Test split will no longer be uploaded to OpenAI.

   - For evaluation, test data will instead be fetched directly from S3.

- DB is now updated with:

   - train_data_url → S3 URL of the training split.

   - test_data_url → S3 URL of the test split.
