### PR TITLE
Langfuse: Add assistant_id as tag in traces

### DIFF
--- a/backend/app/api/routes/responses.py
+++ b/backend/app/api/routes/responses.py
@@ -144,7 +144,7 @@ def process_response(
         name="generate_response_async",
         input={"question": request.question, "assistant_id": request.assistant_id},
         metadata={"callback_url": request.callback_url},
-        tags=[request.assistant_id]
+        tags=[request.assistant_id],
     )
 
     tracer.start_generation(

--- a/backend/app/api/routes/responses.py
+++ b/backend/app/api/routes/responses.py
@@ -144,6 +144,7 @@ def process_response(
         name="generate_response_async",
         input={"question": request.question, "assistant_id": request.assistant_id},
         metadata={"callback_url": request.callback_url},
+        tags=[request.assistant_id]
     )
 
     tracer.start_generation(

--- a/backend/app/core/langfuse/langfuse.py
+++ b/backend/app/core/langfuse/langfuse.py
@@ -55,7 +55,7 @@ class LangfuseTracer:
         name: str,
         input: Dict[str, Any],
         metadata: Optional[Dict[str, Any]] = None,
-        tags: list[str] | None = None
+        tags: list[str] | None = None,
     ):
         metadata = metadata or {}
         metadata["request_id"] = correlation_id.get() or "N/A"
@@ -65,7 +65,7 @@ class LangfuseTracer:
             input=input,
             metadata=metadata,
             session_id=self.session_id,
-            tags=tags ,
+            tags=tags,
         )
 
     def start_generation(

--- a/backend/app/core/langfuse/langfuse.py
+++ b/backend/app/core/langfuse/langfuse.py
@@ -55,6 +55,7 @@ class LangfuseTracer:
         name: str,
         input: Dict[str, Any],
         metadata: Optional[Dict[str, Any]] = None,
+        tags: list[str] | None = None
     ):
         metadata = metadata or {}
         metadata["request_id"] = correlation_id.get() or "N/A"
@@ -64,6 +65,7 @@ class LangfuseTracer:
             input=input,
             metadata=metadata,
             session_id=self.session_id,
+            tags=tags ,
         )
 
     def start_generation(


### PR DESCRIPTION
Added assistant_id as a tag in Langfuse tracing to improve observability and filtering capabilities.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enhanced observability by adding assistant-specific tags to tracing. This enables easier filtering, clearer analytics, and faster issue triage in monitoring tools.
  - No changes to user-facing behavior or workflows; performance and outputs remain the same.
  - Improves supportability and targeted performance insights without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->