### PR TITLE
Add pagination and optional query params to config list endpoint

### DIFF
--- a/backend/app/api/docs/config/list.md
+++ b/backend/app/api/docs/config/list.md
@@ -1,3 +1,7 @@
+query: Search string used for partial matching across configurations
+skip: Number of records to skip for pagination (default: 0)
+limit: Maximum number of records to return (default: 100, max: 100)
+
 Retrieve all configurations for the current project.
 
 Returns a paginated list of configurations ordered by most recently

--- a/backend/app/api/routes/config/config.py
+++ b/backend/app/api/routes/config/config.py
@@ -53,7 +53,7 @@ def create_config(
 def list_configs(
     current_user: AuthContextDep,
     session: SessionDep,
-    query: str = Query(description='search query'),
+    query: str = Query(None, description='search query'),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(100, ge=1, le=100, description="Maximum records to return"),
 ):

--- a/backend/app/api/routes/config/config.py
+++ b/backend/app/api/routes/config/config.py
@@ -53,7 +53,7 @@ def create_config(
 def list_configs(
     current_user: AuthContextDep,
     session: SessionDep,
-    query: str = Query(None, description='search query'),
+    query: str | None = Query(None, description='search query'),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(100, ge=1, le=100, description="Maximum records to return"),
 ):

--- a/backend/app/api/routes/config/config.py
+++ b/backend/app/api/routes/config/config.py
@@ -53,20 +53,17 @@ def create_config(
 def list_configs(
     current_user: AuthContextDep,
     session: SessionDep,
-    query: str | None = Query(None, description='search query'),
+    query: str | None = Query(None, description="search query"),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(100, ge=1, le=100, description="Maximum records to return"),
-):
+) -> APIResponse[list[ConfigPublic]]:
     """
     List all configurations for the current project.
     Ordered by updated_at in descending order.
     """
     config_crud = ConfigCrud(session=session, project_id=current_user.project_.id)
     configs, has_more = config_crud.read_all(query=query, skip=skip, limit=limit)
-    return APIResponse.success_response(
-        data=configs,
-        metadata=dict(has_more=has_more)
-    )
+    return APIResponse.success_response(data=configs, metadata=dict(has_more=has_more))
 
 
 @router.get(

--- a/backend/app/api/routes/config/config.py
+++ b/backend/app/api/routes/config/config.py
@@ -62,9 +62,10 @@ def list_configs(
     Ordered by updated_at in descending order.
     """
     config_crud = ConfigCrud(session=session, project_id=current_user.project_.id)
-    configs = config_crud.read_all(query=query, skip=skip, limit=limit)
+    configs, has_more = config_crud.read_all(query=query, skip=skip, limit=limit)
     return APIResponse.success_response(
         data=configs,
+        metadata=dict(has_more=has_more)
     )
 
 

--- a/backend/app/api/routes/config/config.py
+++ b/backend/app/api/routes/config/config.py
@@ -53,6 +53,7 @@ def create_config(
 def list_configs(
     current_user: AuthContextDep,
     session: SessionDep,
+    query: str = Query(description='search query'),
     skip: int = Query(0, ge=0, description="Number of records to skip"),
     limit: int = Query(100, ge=1, le=100, description="Maximum records to return"),
 ):
@@ -61,7 +62,7 @@ def list_configs(
     Ordered by updated_at in descending order.
     """
     config_crud = ConfigCrud(session=session, project_id=current_user.project_.id)
-    configs = config_crud.read_all(skip=skip, limit=limit)
+    configs = config_crud.read_all(query=query, skip=skip, limit=limit)
     return APIResponse.success_response(
         data=configs,
     )

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -81,7 +81,7 @@ def list_docs(
     ),
 ):
     crud = DocumentCrud(session, current_user.project_.id)
-    documents = crud.read_many(skip, limit)
+    documents, has_more = crud.read_many(skip, limit)
 
     storage = (
         get_cloud_storage(session=session, project_id=current_user.project_.id)
@@ -94,7 +94,7 @@ def list_docs(
         include_url=include_url,
         storage=storage,
     )
-    return APIResponse.success_response(results)
+    return APIResponse.success_response(results, metadata=dict(has_more=has_more))
 
 
 @router.post(

--- a/backend/app/crud/config/config.py
+++ b/backend/app/crud/config/config.py
@@ -84,16 +84,19 @@ class ConfigCrud:
             )
         )
         return self.session.exec(statement).one_or_none()
+    
+    def read_all(self, query: str | None, skip: int = 0, limit: int = 100) -> list[Config]:
+        filters = [
+            Config.project_id == self.project_id,
+            Config.deleted_at.is_(None),
+        ]
 
-    def read_all(self, skip: int = 0, limit: int = 100) -> list[Config]:
+        if query:
+            filters.append(Config.name.ilike(f"{query}%"))
+
         statement = (
             select(Config)
-            .where(
-                and_(
-                    Config.project_id == self.project_id,
-                    Config.deleted_at.is_(None),
-                )
-            )
+            .where(and_(*filters))
             .order_by(Config.updated_at.desc())
             .offset(skip)
             .limit(limit)

--- a/backend/app/crud/config/config.py
+++ b/backend/app/crud/config/config.py
@@ -85,7 +85,7 @@ class ConfigCrud:
         )
         return self.session.exec(statement).one_or_none()
     
-    def read_all(self, query: str | None, skip: int = 0, limit: int = 100) -> list[Config]:
+    def read_all(self, query: str | None, skip: int = 0, limit: int = 100) -> tuple[list[Config], bool]:
         filters = [
             Config.project_id == self.project_id,
             Config.deleted_at.is_(None),
@@ -99,9 +99,15 @@ class ConfigCrud:
             .where(and_(*filters))
             .order_by(Config.updated_at.desc())
             .offset(skip)
-            .limit(limit)
+            .limit(limit + 1)
         )
-        return self.session.exec(statement).all()
+        configs =  self.session.exec(statement).all()
+        has_more = False
+        if limit is not None and len(configs) > limit:
+            has_more = True
+            configs = configs[:limit]
+
+        return configs, has_more
 
     def update_or_raise(self, config_id: UUID, config_update: ConfigUpdate) -> Config:
         config = self.exists_or_raise(config_id)

--- a/backend/app/crud/config/config.py
+++ b/backend/app/crud/config/config.py
@@ -84,8 +84,10 @@ class ConfigCrud:
             )
         )
         return self.session.exec(statement).one_or_none()
-    
-    def read_all(self, query: str | None, skip: int = 0, limit: int = 100) -> tuple[list[Config], bool]:
+
+    def read_all(
+        self, query: str | None, skip: int = 0, limit: int = 100
+    ) -> tuple[list[Config], bool]:
         filters = [
             Config.project_id == self.project_id,
             Config.deleted_at.is_(None),
@@ -101,7 +103,7 @@ class ConfigCrud:
             .offset(skip)
             .limit(limit + 1)
         )
-        configs =  self.session.exec(statement).all()
+        configs = self.session.exec(statement).all()
         has_more = False
         if limit is not None and len(configs) > limit:
             has_more = True

--- a/backend/app/crud/document/document.py
+++ b/backend/app/crud/document/document.py
@@ -37,10 +37,11 @@ class DocumentCrud:
         self,
         skip: int | None = None,
         limit: int | None = None,
-    ) -> list[Document]:
+    ) -> tuple[list[Document], bool]:
         statement = select(Document).where(
             and_(Document.project_id == self.project_id, Document.is_deleted.is_(False))
         )
+        statement = statement.order_by(Document.inserted_at.desc())
 
         if skip is not None:
             if skip < 0:
@@ -64,10 +65,16 @@ class DocumentCrud:
                         exc_info=True,
                     )
                     raise
-            statement = statement.limit(limit)
+            statement = statement.limit(limit + 1)
 
         documents = self.session.exec(statement).all()
-        return documents
+
+        has_more = False
+        if limit is not None and len(documents) > limit:
+            has_more = True
+            documents = documents[:limit]
+
+        return documents, has_more
 
     def read_each(self, doc_ids: list[UUID]):
         statement = select(Document).where(

--- a/backend/app/tests/api/routes/configs/test_config.py
+++ b/backend/app/tests/api/routes/configs/test_config.py
@@ -141,6 +141,7 @@ def test_list_configs(
     assert data["success"] is True
     assert isinstance(data["data"], list)
     assert len(data["data"]) >= 3
+    assert "has_more" in data["metadata"]
 
     config_names = [c["name"] for c in data["data"]]
     for config in created_configs:
@@ -453,3 +454,28 @@ def test_configs_isolated_by_project(
     # Verify we only get configs from user's project
     for config_data in data["data"]:
         assert config_data["project_id"] == user_api_key.project_id
+
+
+def test_list_configs_with_query(
+    db: Session,
+    client: TestClient,
+    user_api_key: TestAuthContext,
+) -> None:
+    """Test listing configs filtered by query param."""
+    create_test_config(db=db, project_id=user_api_key.project_id, name="search-alpha")
+    create_test_config(db=db, project_id=user_api_key.project_id, name="search-beta")
+    create_test_config(db=db, project_id=user_api_key.project_id, name="other-config")
+
+    response = client.get(
+        f"{settings.API_V1_STR}/configs/",
+        headers={"X-API-KEY": user_api_key.key},
+        params={"query": "search"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    returned_names = [c["name"] for c in data["data"]]
+    assert "search-alpha" in returned_names
+    assert "search-beta" in returned_names
+    assert all("search" in name for name in returned_names)
+    assert "other-config" not in returned_names

--- a/backend/app/tests/crud/config/test_config.py
+++ b/backend/app/tests/crud/config/test_config.py
@@ -177,7 +177,7 @@ def test_read_all_configs(db: Session) -> None:
     config3 = create_test_config(db, project_id=project.id, name="config-3")
 
     config_crud = ConfigCrud(session=db, project_id=project.id)
-    configs = config_crud.read_all()
+    configs, has_more = config_crud.read_all(query=None)
 
     config_ids = [c.id for c in configs]
     assert config1.id in config_ids
@@ -196,10 +196,11 @@ def test_read_all_configs_pagination(db: Session) -> None:
     config_crud = ConfigCrud(session=db, project_id=project.id)
 
     # Test skip and limit
-    configs_page1 = config_crud.read_all(skip=0, limit=2)
-    configs_page2 = config_crud.read_all(skip=2, limit=2)
+    configs_page1, has_more = config_crud.read_all(query=None, skip=0, limit=2)
+    configs_page2, _ = config_crud.read_all(query=None, skip=2, limit=2)
 
     assert len(configs_page1) == 2
+    assert has_more is True
     assert len(configs_page2) == 2
     assert configs_page1[0].id != configs_page2[0].id
 
@@ -219,7 +220,7 @@ def test_read_all_configs_ordered_by_updated_at(db: Session) -> None:
         config1.id, ConfigUpdate(description="Updated description")
     )
 
-    configs = config_crud.read_all()
+    configs, _ = config_crud.read_all(query=None)
 
     # config1 should be first because it was most recently updated
     assert configs[0].id == config1.id
@@ -237,7 +238,7 @@ def test_read_all_configs_excludes_deleted(db: Session) -> None:
     # Delete config1
     config_crud.delete_or_raise(config1.id)
 
-    configs = config_crud.read_all()
+    configs, _ = config_crud.read_all(query=None)
 
     config_ids = [c.id for c in configs]
     assert config1.id not in config_ids
@@ -253,11 +254,35 @@ def test_read_all_configs_different_projects(db: Session) -> None:
     config2 = create_test_config(db, project_id=project2.id, name="config-2")
 
     config_crud = ConfigCrud(session=db, project_id=project1.id)
-    configs = config_crud.read_all()
+    configs, _ = config_crud.read_all(query=None)
 
     config_ids = [c.id for c in configs]
     assert config1.id in config_ids
     assert config2.id not in config_ids
+
+
+def test_read_all_configs_query_filter(db: Session) -> None:
+    """Test that query param filters configs by name prefix."""
+    project = create_test_project(db)
+    create_test_config(db, project_id=project.id, name="alpha-config")
+    create_test_config(db, project_id=project.id, name="beta-config")
+
+    config_crud = ConfigCrud(session=db, project_id=project.id)
+    configs, _ = config_crud.read_all(query="alpha")
+
+    assert len(configs) == 1
+    assert configs[0].name == "alpha-config"
+
+
+def test_read_all_configs_has_more_false(db: Session) -> None:
+    """Test has_more is False when results fit within limit."""
+    project = create_test_project(db)
+    create_test_config(db, project_id=project.id, name="only-config")
+
+    config_crud = ConfigCrud(session=db, project_id=project.id)
+    _, has_more = config_crud.read_all(query=None, limit=10)
+
+    assert has_more is False
 
 
 def test_update_config_name(db: Session) -> None:

--- a/backend/app/tests/crud/documents/documents/test_crud_document_read_many.py
+++ b/backend/app/tests/crud/documents/documents/test_crud_document_read_many.py
@@ -24,7 +24,7 @@ class TestDatabaseReadMany:
         store: DocumentStore,
     ) -> None:
         crud = DocumentCrud(db, store.project.id)
-        docs = crud.read_many()
+        docs, _ = crud.read_many()
         assert len(docs) == self._ndocs
 
     def test_deleted_docs_are_excluded(
@@ -33,7 +33,8 @@ class TestDatabaseReadMany:
         store: DocumentStore,
     ) -> None:
         crud = DocumentCrud(db, store.project.id)
-        assert all(x.is_deleted is False for x in crud.read_many())
+        docs, _ = crud.read_many()
+        assert all(x.is_deleted is False for x in docs)
 
     def test_skip_is_respected(
         self,
@@ -42,7 +43,7 @@ class TestDatabaseReadMany:
     ) -> None:
         crud = DocumentCrud(db, store.project.id)
         skip = self._ndocs // 2
-        docs = crud.read_many(skip=skip)
+        docs, _ = crud.read_many(skip=skip)
 
         assert len(docs) == self._ndocs - skip
 
@@ -52,7 +53,7 @@ class TestDatabaseReadMany:
         store: DocumentStore,
     ) -> None:
         crud = DocumentCrud(db, store.project.id)
-        docs = crud.read_many(skip=0)
+        docs, _ = crud.read_many(skip=0)
         assert len(docs) == self._ndocs
 
     def test_big_skip_is_empty(
@@ -62,7 +63,8 @@ class TestDatabaseReadMany:
     ) -> None:
         crud = DocumentCrud(db, store.project.id)
         skip = self._ndocs + 1
-        assert not crud.read_many(skip=skip)
+        docs, _ = crud.read_many(skip=skip)
+        assert not docs
 
     def test_negative_skip_raises_exception(
         self,
@@ -80,7 +82,7 @@ class TestDatabaseReadMany:
     ) -> None:
         crud = DocumentCrud(db, store.project.id)
         limit = self._ndocs // 2
-        docs = crud.read_many(limit=limit)
+        docs, _ = crud.read_many(limit=limit)
 
         assert len(docs) == limit
 
@@ -90,7 +92,8 @@ class TestDatabaseReadMany:
         store: DocumentStore,
     ) -> None:
         crud = DocumentCrud(db, store.project.id)
-        assert not crud.read_many(limit=0)
+        docs, _ = crud.read_many(limit=0)
+        assert not docs
 
     def test_negative_limit_raises_exception(
         self,
@@ -109,6 +112,6 @@ class TestDatabaseReadMany:
         crud = DocumentCrud(db, store.project.id)
         limit = self._ndocs
         skip = limit // 2
-        docs = crud.read_many(skip=skip, limit=limit)
+        docs, _ = crud.read_many(skip=skip, limit=limit)
 
         assert len(docs) == limit - skip

--- a/backend/app/tests/crud/documents/documents/test_crud_document_update.py
+++ b/backend/app/tests/crud/documents/documents/test_crud_document_update.py
@@ -18,9 +18,9 @@ class TestDatabaseUpdate:
     def test_update_adds_one(self, db: Session, documents: DocumentMaker) -> None:
         crud = DocumentCrud(db, documents.project_id)
 
-        before = crud.read_many()
+        before, _ = crud.read_many()
         crud.update(next(documents))
-        after = crud.read_many()
+        after, _ = crud.read_many()
 
         assert len(before) + 1 == len(after)
 


### PR DESCRIPTION
Issue: #732 
## Summary

- Previously, the config list endpoint had no search capability and didn't indicate whether more records exist beyond the current page. This made it difficult for clients to:
- Filter configs by name without fetching everything and filtering client-side
- Implement proper pagination UI (e.g., "Load more" buttons) since there was no signal for additional records

This PR adds an optional query param for name-based search and a has_more flag in the response metadata, enabling efficient server-side filtering and accurate pagination.



## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add search-by-name for configurations and explicit pagination metadata (has_more) on config and document list responses.

* **Documentation**
  * API docs updated to document query, skip, and limit parameters and the pagination metadata.

* **Tests**
  * Tests updated/added to cover search filtering and the new pagination metadata behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->