### PR TITLE
PR Formatter: Skip PR  formatter  for depandabot opened PRs

### DIFF
--- a/.github/workflows/pr-formatter.yml
+++ b/.github/workflows/pr-formatter.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   format-pr:
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Rewrite PR body

--- a/.github/workflows/pr-formatter.yml
+++ b/.github/workflows/pr-formatter.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   format-pr:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Rewrite PR body


### PR DESCRIPTION
## Issue

Closes #1068 

## Summary

- **Before:** The PR formatter processed all pull requests, including those opened by Dependabot.
- **Now:** The PR formatter skips pull requests opened by Dependabot.
- Required changes to the PR formatter logic to include checks for the author of the pull request.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.