### PR TITLE
fix(langfuse): Revert OTel tracer integration

### DIFF
--- a/backend/app/core/langfuse/langfuse.py
+++ b/backend/app/core/langfuse/langfuse.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import threading
 import uuid
 from collections.abc import Callable
 from functools import wraps
@@ -10,7 +9,6 @@ from asgi_correlation_id import correlation_id
 from langfuse import Langfuse, LangfuseOtelSpanAttributes
 from langfuse._client.span import LangfuseGeneration, LangfuseSpan
 from langfuse.api.core.api_error import ApiError
-from opentelemetry.sdk.trace import TracerProvider
 
 from app.models.llm import (
     AudioOutput,
@@ -21,25 +19,6 @@ from app.models.llm import (
 )
 
 logger = logging.getLogger(__name__)
-
-_LANGFUSE_TRACER_PROVIDER: TracerProvider | None = None
-_LANGFUSE_TRACER_PROVIDER_LOCK = threading.Lock()
-
-
-def get_langfuse_tracer_provider() -> TracerProvider:
-    """Isolated OTel provider for Langfuse so LLM spans never reach Sentry.
-
-    Sentry's SpanProcessor sits on the global provider and exports every span
-    with no per-project filter; sharing it surfaces each Langfuse span in Sentry
-    as a duplicate root trace. Langfuse's own processors filter by public_key, so
-    one shared isolated provider stays multi-tenant safe.
-    """
-    global _LANGFUSE_TRACER_PROVIDER
-    if _LANGFUSE_TRACER_PROVIDER is None:
-        with _LANGFUSE_TRACER_PROVIDER_LOCK:
-            if _LANGFUSE_TRACER_PROVIDER is None:
-                _LANGFUSE_TRACER_PROVIDER = TracerProvider()
-    return _LANGFUSE_TRACER_PROVIDER
 
 
 def format_langfuse_error(exc: Exception) -> str:
@@ -174,7 +153,6 @@ class LangfuseTracer:
                     secret_key=credentials["secret_key"],
                     host=credentials["host"],
                     tracing_enabled=True,  # This ensures the client is active
-                    tracer_provider=get_langfuse_tracer_provider(),
                 )
             except Exception as e:
                 logger.warning(
@@ -333,7 +311,6 @@ def observe_llm_execution(
                     public_key=credentials.get("public_key"),
                     secret_key=credentials.get("secret_key"),
                     host=credentials.get("host"),
-                    tracer_provider=get_langfuse_tracer_provider(),
                 )
                 logger.info(
                     f"[observe_llm_execution] Tracing enabled | session_id={session_id or 'auto'}"

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -348,14 +348,11 @@ def get_anthropic_client(session: Session, org_id: int, project_id: int) -> Anth
 
 
 def _build_langfuse_client(credentials: dict[str, Any]) -> Langfuse:
-    from app.core.langfuse.langfuse import get_langfuse_tracer_provider
-
     return Langfuse(
         public_key=credentials["public_key"],
         secret_key=credentials["secret_key"],
         host=credentials["host"],
         timeout=60,
-        tracer_provider=get_langfuse_tracer_provider(),
     )
 
 


### PR DESCRIPTION
## Issue

Closes #PLEASE_TYPE_ISSUE_NUMBER

## Summary

- **Before:** Integrated OTel tracer provider for multi-tenant safety.
- **Now:** Reverted the commit that introduced the integration.
- Reverting the previous integration.
- Restoring the previous state without the OTel tracer provider.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.

<details><summary>Original PR description</summary>

…ulti-tenant safety"

This reverts commit b46301b037aa613741924eede57827a805b6c5c5.

## Issue

Closes #PLEASE_TYPE_ISSUE_NUMBER

## Summary

Explain the **motivation** for making this change. What existing problem does the pull request solve?

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.


</details>