### PR TITLE
feat(typecheck): Add type-checking command

### DIFF
--- a/.claude/agents/senior-engineer.md
+++ b/.claude/agents/senior-engineer.md
@@ -79,6 +79,19 @@ to what the task needs.
 - Naming: `list_*` plural fetch, `get_*` singleton; `Enum` suffix on enum classes.
 - Timestamps are `inserted_at` / `updated_at`, never `created_at`.
 
+## Before finishing: type-check
+
+After editing any file — **always when you touched `app/models/`** — type-check the files you changed:
+
+```bash
+cd backend && bash scripts/pyright.sh <changed files>   # e.g. app/models/foo.py
+```
+
+Runs pyright via `uvx` (no `uv.lock` churn; config in `[tool.pyright]`). Fix real type errors you
+introduced before emitting the summary; a model change ripples into crud/service typing, so re-check
+those files too if you edited them. Distinguish real bugs from pre-existing stub noise — don't fix
+what you didn't touch. Same as the `/typecheck` command.
+
 ## After building
 
 Emit ONE summary (not one per layer):

--- a/.claude/commands/typecheck.md
+++ b/.claude/commands/typecheck.md
@@ -1,0 +1,24 @@
+---
+description: Run pyright type checking on Python files and triage the errors.
+---
+
+Run pyright over the backend and report type errors in this FastAPI + SQLModel service.
+
+## Run
+
+From the repo root:
+
+```bash
+cd backend && bash scripts/pyright.sh $ARGUMENTS
+```
+
+- No `$ARGUMENTS` → checks all of `app/` (config in `backend/pyproject.toml` `[tool.pyright]`).
+- `$ARGUMENTS` → narrow to those paths/files, e.g. `/typecheck app/services/response`.
+- Pyright runs via `uvx` (ephemeral) so it never mutates `uv.lock`.
+
+## Report
+
+1. Group errors by file, most-affected first.
+2. For each: `file:line` — the error, then the concrete fix (narrow the type, add an annotation, guard the `None`, etc.).
+3. Separate real type bugs from noise (missing third-party stubs, `# type: ignore` candidates). Flag which is which.
+4. Do NOT auto-edit code — surface findings and let the user pick what to fix. If asked to fix, follow the layer conventions in `.claude/conventions/`.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -87,6 +87,15 @@ ai-cli = "app.cli.main:cli"
 strict = true
 exclude = ["venv", ".venv", "alembic"]
 
+[tool.pyright]
+include = ["app"]
+exclude = ["**/__pycache__", ".venv", "venv", "app/alembic"]
+pythonVersion = "3.12"
+typeCheckingMode = "standard"
+# Resolve project deps from the local venv (pyright runs in an isolated uvx env).
+venvPath = "."
+venv = ".venv"
+
 [tool.ruff]
 target-version = "py312"
 exclude = ["alembic"]

--- a/backend/scripts/pyright.sh
+++ b/backend/scripts/pyright.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+# Pyright runs via uvx (ephemeral) so it never touches uv.lock.
+# Default target is app/; pass paths/files to narrow the check.
+TARGET="${*:-app}"
+
+uvx pyright $TARGET


### PR DESCRIPTION
## Issue

Closes:

## Summary

- **Before:** No type-checking command or pyright config in the repo.
- **Now:** 
  - Added a pyright-based type-check command and its config.
  - `backend/scripts/pyright.sh` — runs pyright via `uvx` (ephemeral, never touches `uv.lock`); defaults to `app/`, accepts paths to narrow the check.
  - `[tool.pyright]` config in `backend/pyproject.toml` — `include = ["app"]`, standard mode, resolves deps from local `.venv`.
  - `/typecheck` slash command (`.claude/commands/typecheck.md`) — runs the script, groups errors by file, separates real type bugs from stub noise, does not auto-edit.
  - `senior-engineer` agent now type-checks changed files before finishing (required when `app/models/` is touched).

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Tooling/config only — no application code changed. Run `cd backend && bash scripts/pyright.sh` or `/typecheck` to try it.