### PR TITLE
feat(ci): Add Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,74 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+  pull_request:
+    types: [labeled]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # lets Claude read CI results on PRs
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  review:
+    if: github.event_name == 'pull_request' && github.event.label.name == 'ready-for-review'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this PR against the repository's own review checklist.
+
+            1. Read `.claude/commands/pr-review.md` and follow it from the "What to check"
+               section onward, together with "How to write the comments" and "Output format".
+            2. Skip its "Gather the diff" section — that one assumes a local clone. Use
+               `gh pr diff` for the diff and `gh pr view` for the description and commits.
+            3. Read the full files at non-trivial change sites before judging them, and
+               check `docs/wiki/INDEX.md` for the touched module before claiming that a
+               helper, service, or entity does not already exist.
+
+            Post specific findings as inline comments citing path:line, and the summary as
+            a single top-level comment. Review only — do not modify files.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Issue

Closes #PLEASE_TYPE_ISSUE_NUMBER

## Summary

- **Before:** No automated workflow for reviews or interactive assistant.
- **Now:** Introduces a workflow with two jobs: one for interactive assistance and one for automated review.
- Jobs trigger on specific actions and utilize defined criteria for reviews.
- Supports fetching PR details with a shallow checkout.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

- **`ready-for-review` is the same label CodeRabbit uses** (`.coderabbit.yaml`), so labelling a PR now fires both reviewers. If that turns out to be noise, drop one — changing the label here is a one-line edit.
- **Cost:** every trigger is a full agent run billed to the API key. `concurrency` with `cancel-in-progress` on the review job keeps a remove/re-add of the label from stacking runs.
- **Fork PRs:** the `pull_request` trigger doesn't expose secrets to forks, so the review job silently no-ops there. Deliberate — `pull_request_target` would expose the key to untrusted code.
- **`actions/checkout@v7`** matches `continuous-integration.yml` (upstream's example is on v6).
- The repo's `Stop` hook (`wiki-update.sh`) also applies to these runs. On the read-only review job it exits 0; on the `claude` job it will nudge for a `docs/wiki/` update when the change is structural, which is the intended behaviour.

<details><summary>Original PR description</summary>

## Issue

N/A — infra setup.

## Summary

Adds `.github/workflows/claude.yml` with two jobs:

| Job | Trigger | What it does |
|---|---|---|
| `claude` | `@claude` in an issue body/title, a PR comment, or a review | Interactive assistant — answers, or pushes a fix commit |
| `review` | `ready-for-review` label added to a PR | Automated review, posted as inline comments + one summary comment |

The `review` job doesn't carry its own review criteria. It reads `.claude/commands/pr-review.md` from the checkout and follows it from "What to check" onward, so the bot review and a locally-run `/pr-review` apply the same conventions and output format. Updating the checklist updates both.

It skips that file's "Gather the diff" section (which assumes a local clone with full history) and uses `gh pr diff` / `gh pr view` instead — the checkout is `fetch-depth: 1`.

## Before this can run

- [ ] Install the Claude GitHub App on the `ProjectTech4DevAI` org — needs an org owner, not just repo admin.
- [ ] Add `ANTHROPIC_API_KEY` as a repository (or org) Actions secret.

Until both are done, the jobs are inert — nothing else in CI is affected.

## Notes

- **`ready-for-review` is the same label CodeRabbit uses** (`.coderabbit.yaml`), so labelling a PR now fires both reviewers. If that turns out to be noise, drop one — changing the label here is a one-line edit.
- **Cost:** every trigger is a full agent run billed to the API key. `concurrency` with `cancel-in-progress` on the review job keeps a remove/re-add of the label from stacking runs.
- **Fork PRs:** the `pull_request` trigger doesn't expose secrets to forks, so the review job silently no-ops there. Deliberate — `pull_request_target` would expose the key to untrusted code.
- **`actions/checkout@v7`** matches `continuous-integration.yml` (upstream's example is on v6).
- The repo's `Stop` hook (`wiki-update.sh`) also applies to these runs. On the read-only review job it exits 0; on the `claude` job it will nudge for a `docs/wiki/` update when the change is structural, which is the intended behaviour.

## Checklist

- [x] YAML validated (parses, both jobs present)
- [ ] Ran `fastapi run --reload app/main.py` — N/A, CI-only change
- [ ] Tests — N/A, no application code touched

</details>