### PR TITLE
fix(llm): Remove duplicate property ordering

### DIFF
--- a/backend/app/services/assessment/mappers.py
+++ b/backend/app/services/assessment/mappers.py
@@ -83,6 +83,10 @@ def _convert_json_schema_to_google(schema: dict) -> dict:
         else normalized_schema
     )
 
+    # The SDK's model_dump emits snake_case `property_ordering`; Vertex merges it
+    # with our camelCase key into a duplicated ordering and rejects the request,
+    # so keep exactly one ordering key.
+    google_schema.pop("property_ordering", None)
     if "properties" in google_schema and "propertyOrdering" not in google_schema:
         google_schema["propertyOrdering"] = list(
             normalized_schema.get("required", [])

--- a/backend/app/services/llm/mappers.py
+++ b/backend/app/services/llm/mappers.py
@@ -127,6 +127,10 @@ def _convert_json_schema_to_google(schema: dict[str, Any]) -> dict[str, Any]:
         else normalized_schema
     )
 
+    # The SDK's model_dump emits snake_case `property_ordering`; Vertex merges it
+    # with our camelCase key into a duplicated ordering and rejects the request,
+    # so keep exactly one ordering key.
+    google_schema.pop("property_ordering", None)
     if "properties" in google_schema and "propertyOrdering" not in google_schema:
         google_schema["propertyOrdering"] = list(
             normalized_schema.get("required", [])


### PR DESCRIPTION
## Issue

Closes #PLEASE_TYPE_ISSUE_NUMBER

## Summary

- **Before:** The Vertex rejected each batch assessment row due to duplicate `property_ordering` fields in the schema.
- **Now:** The SDK's snake_case `property_ordering` is removed before adding the required camelCase key, preventing duplication.
- Required modifications in both `services/assessment/mappers.py` and `services/llm/mappers.py`.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `fastapi run --reload app/main.py` or `docker compose up` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.

## Notes

Please add here if any other information is required for the reviewer.

<details><summary>Original PR description</summary>

## Problem

Every google-gcp batch assessment that uses a `json_output_schema` fails: Vertex rejects each row with

```
Unable to submit request because property_ordering contains duplicate field Idea_Feedback
```

(observed on prod assessment `432ef1d9`, batch job 1096 — all 998 rows errored).

## Root cause

`_convert_json_schema_to_google()` normalizes the schema through `genai_transformers.t_schema()` and dumps it with `model_dump(mode="json")` — **without `by_alias`**, so the SDK emits snake_case `property_ordering`. The guard below only checks camelCase:

```python
if "properties" in google_schema and "propertyOrdering" not in google_schema:
```

so the mapper adds a second, camelCase ordering. Vertex merges both keys into one ordering where every field appears twice, and rejects the request.

## Fix

Pop the SDK's snake_case `property_ordering` before adding the required-order camelCase key, in both copies of the converter (`services/assessment/mappers.py`, `services/llm/mappers.py`).

## Verification

- Reproduced locally: current mapper output contains both `propertyOrdering` and `property_ordering` for the failing schema — byte-identical to the request captured in the batch-1096 predictions JSONL.
- Ran a live Vertex batch job (gemini-2.5-flash-lite) with the fixed schema: `JOB_STATE_SUCCEEDED`, all rows returned valid structured output matching the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>